### PR TITLE
feat: allow ability to add containers for things like gcp registry auth

### DIFF
--- a/spacelift-worker-pool/templates/deployment.yaml
+++ b/spacelift-worker-pool/templates/deployment.yaml
@@ -129,6 +129,9 @@ spec:
             {{- with .Values.dind.extraVolumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+        {{- if .Values.additionalContainers }}
+        {{- toYaml .Values.additionalContainers | nindent 8 }}
+        {{- end }}
       volumes:
         - name: launcher-storage
       {{- if not .Values.storageVolume }}

--- a/spacelift-worker-pool/templates/statefulset.yaml
+++ b/spacelift-worker-pool/templates/statefulset.yaml
@@ -125,6 +125,9 @@ spec:
             {{- with .Values.dind.extraVolumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+        {{- if .Values.additionalContainers }}
+        {{- toYaml .Values.additionalContainers | nindent 8 }}
+        {{- end }}
       volumes:
         - name: launcher-storage
       {{- if not (or .Values.storageVolume .Values.storageVolumeClaimTemplateSpec) }}

--- a/spacelift-worker-pool/values.yaml
+++ b/spacelift-worker-pool/values.yaml
@@ -69,6 +69,8 @@ dind:
   # extraVolumeMounts adds extra volume mounts to the dind container.
   extraVolumeMounts: []
 
+additionalContainers: []
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
## Background
We use GCP for our Cloud provider and a few additional binaries/private-providers are needed inside our terraform runner container. We've pushed this built container (built ontop of the spacelift runner) to our GCP registry. Our deployment in Kubernetes is using [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) to attach an existing service account from IAM to the pod itself.

I've attempted to follow [these docs](https://docs.spacelift.io/integrations/docker.html#customizing-the-runner-image) for our private worker pool that is init'd by this helm chart. I finally found the right combination where the `docker login`- config.json needs to be available inside the `launcher` container as well.

## Solution
To accomplish this, I added a third container to the pod that routinely hits GCP's metadata server (an internal thing) to run the `docker login` piece, and also shared a common directory so each container can access the resulting `config.json`.

example values.yaml:

```yaml
additionalContainers:
  - name: gcloud-auth-docker
    image: google/cloud-sdk
    env:
      - name: DOCKER_HOST
        value: tcp://localhost:2375
    volumeMounts:
      - name: launcher-storage
        mountPath: /var/lib/docker
        subPath: docker
      - name: launcher-storage
        mountPath: /opt/docker-cfg
        subPath: docker-cfg
    command:
      - /bin/bash
      - -c
    args:
      - >-
        apt update && apt install -y jq; 
        while true; 
        do
            curl -sS --header "Metadata-Flavor:Google" http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token | jq -r '.access_token' | docker --config /opt/docker-cfg login -u oauth2accesstoken --password-stdin https://us-central1-docker.pkg.dev;
            sleep 900;
        done

launcher:
  extraEnv:
    - name: SPACELIFT_DOCKER_CONFIG_DIR
      value: /opt/docker-cfg
  extraVolumeMounts:
    - name: launcher-storage
      mountPath: /opt/docker-cfg
      subPath: docker-cfg


dind:
  extraVolumeMounts:
    - name: launcher-storage
      mountPath: /root/.docker
      subPath: docker-cfg

storageVolume:
  ephemeral:
    volumeClaimTemplate:
      spec:
        accessModes: ["ReadWriteOnce"]
        storageClassName: "standard"
        resources:
          requests:
            storage: 200Gi
```

Note: `curl -sS --header "Metadata-Flavor:Google" http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token ` returns:
```
{
    "access_token": "<some token>",
    "expires_in": 1234,
    "token_type": "Bearer"
}
```
