### PR TITLE
feat: add common configuration options such as deployment annotations…

### DIFF
--- a/spacelift-worker-pool/templates/deployment.yaml
+++ b/spacelift-worker-pool/templates/deployment.yaml
@@ -8,9 +8,16 @@ metadata:
     {{- with .Values.extraLabels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.replicasEnabled  }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  {{- with .Values.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
   {{- end }}
   selector:
     matchLabels:
@@ -80,6 +87,10 @@ spec:
             {{- with .Values.launcher.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- with .Values.launcher.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12}}
+          {{- end }}
           volumeMounts:
             - name: launcher-storage
               mountPath: /opt/spacelift
@@ -110,6 +121,10 @@ spec:
             {{- with .Values.dind.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- with .Values.dind.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12}}
+          {{- end }}
           lifecycle:
             preStop:
               exec:
@@ -143,6 +158,10 @@ spec:
         {{- with .Values.volumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8}}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/spacelift-worker-pool/templates/statefulset.yaml
+++ b/spacelift-worker-pool/templates/statefulset.yaml
@@ -8,9 +8,16 @@ metadata:
     {{- with .Values.extraLabels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.replicasEnabled  }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  {{- with .Values.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
   {{- end }}
   selector:
     matchLabels:
@@ -81,6 +88,10 @@ spec:
             {{- with .Values.launcher.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- with .Values.launcher.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12}}
+          {{- end }}
           volumeMounts:
             - name: launcher-storage
               mountPath: /opt/spacelift
@@ -106,6 +117,10 @@ spec:
             {{- with .Values.dind.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- with .Values.dind.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12}}
+          {{- end }}
           lifecycle:
             preStop:
               exec:
@@ -139,6 +154,10 @@ spec:
         {{- with .Values.volumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8}}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/spacelift-worker-pool/values.yaml
+++ b/spacelift-worker-pool/values.yaml
@@ -5,6 +5,8 @@ replicaCount: 1
 # terminationGracePeriodSeconds specifies how long Kubernetes gives a worker pod to gracefully
 # terminate before forcibly killing it.
 terminationGracePeriodSeconds: 30
+# revisionHistoryLimit controls the amount of past replica sets that are kept
+# revisionHistoryLimit: 3
 
 credentials:
   # create defines whether a secret should be created for the worker pool credentials. If you want to pass
@@ -29,6 +31,7 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+annotations: {}
 extraLabels: {}
 podAnnotations: {}
 extraPodLabels: {}
@@ -49,6 +52,8 @@ launcher:
   securityContext: {}
   # extraEnv allows you to inject additional environment variables to the launcher container.
   extraEnv: []
+  # envFrom allows you to inject all values from secrets and config maps as environment variables to the launcher container
+  envFrom: []
   # extraVolumeMounts adds extra volume mounts to the launcher container.
   extraVolumeMounts: []
 
@@ -66,6 +71,8 @@ dind:
   resources: {}
   # extraEnv allows you to inject additional environment variables to the dind container.
   extraEnv: []
+  # envFrom allows you to inject all values from secrets and config maps as environment variables to the dind container
+  envFrom: []
   # extraVolumeMounts adds extra volume mounts to the dind container.
   extraVolumeMounts: []
 
@@ -76,6 +83,8 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+topologySpreadConstraints: []
 
 # volumes specified extra volumes to attach to Deployment / StatefulSet.
 volumes: []

--- a/vcs-agent/templates/deployment.yaml
+++ b/vcs-agent/templates/deployment.yaml
@@ -4,8 +4,15 @@ metadata:
   name: {{ include "vcs-agent.fullname" . }}
   labels:
     {{- include "vcs-agent.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- with .Values.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "vcs-agent.selectorLabels" . | nindent 6 }}
@@ -52,8 +59,16 @@ spec:
             {{- with .Values.vcsagent.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- with .Values.vcsagent.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12}}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8}}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/vcs-agent/values.yaml
+++ b/vcs-agent/values.yaml
@@ -1,4 +1,6 @@
 replicaCount: 1
+# revisionHistoryLimit controls the amount of past replica sets that are kept
+# revisionHistoryLimit: 3
 
 credentials:
   # create defines whether a secret should be created for the VCS Agent credentials. If you want to pass
@@ -36,7 +38,10 @@ serviceAccount:
 vcsagent:
   extraEnv: []
   # extraVolumeMounts adds extra volume mounts to the launcher container.
+  # envFrom allows you to inject all values from secrets and config maps as environment variables to the vcsagent container
+  envFrom: []
 
+annotations: {}
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -67,3 +72,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+topologySpreadConstraints: []


### PR DESCRIPTION
Just some common configuration options we currently have to patch into our resources via kustomize after the helm rendering.

1. deployment annotations are quite handy for stuff like automatic redeployments whenever a secret / configmap that is used by the deployment is changed (e.g. via https://github.com/stakater/Reloader)
2. topologySpreadConstraints allows for better high availability setups
3. envFrom allows to neatly inject all configmap / secret values without having to redefine all of them in extraEnvs
4. revisionHistoryLimit removes some unnecessary resource clutter