### PR TITLE
fix: pin DinD version to prevent iptables issue

### DIFF
--- a/spacelift-worker-pool/values.yaml
+++ b/spacelift-worker-pool/values.yaml
@@ -63,9 +63,9 @@ dind:
     # repository specifies the docker repository containing the dind image.
     repository: "docker"
     # pullPolicy defines the pull policy for the image.
-    pullPolicy: "Always"
+    pullPolicy: "IfNotPresent"
     # tag specifies the image tag to use.
-    tag: "dind"
+    tag: "23.0.6-dind"
     # (optional) digest specifies the image digest to use.
     # digest: "sha256:84a6bcc230a55058ba27c72a29903557c5bcf1c805f9360391e8fafaf4edaca4"
   resources: {}


### PR DESCRIPTION
It looks like the latest version of dind is causing issues in certain hosting environments. It may be due to this issue: https://github.com/docker-library/docker/issues/467.

Let's pin to a known-working version of `dind`.