### PR TITLE
Allow chart versions to be overridden

### DIFF
--- a/.github/workflows/chart-publish-prod.yml
+++ b/.github/workflows/chart-publish-prod.yml
@@ -75,17 +75,17 @@ jobs:
       - name: Package Spacelift Worker Pool chart
         run: |
           helm package --version "$CHART_VERSION" --destination build/chart/worker-pool spacelift-worker-pool/
-          helm s3 push --relative build/chart/worker-pool/spacelift-worker-${CHART_VERSION}.tgz spacelift
+          helm s3 push --force --relative build/chart/worker-pool/spacelift-worker-${CHART_VERSION}.tgz spacelift
 
       - name: Package Spacelift VCS Agent chart
         run: |
           helm package --version "$CHART_VERSION" --destination build/chart/vcs-agent vcs-agent/
-          helm s3 push --relative build/chart/vcs-agent/vcs-agent-${CHART_VERSION}.tgz spacelift
+          helm s3 push --force --relative build/chart/vcs-agent/vcs-agent-${CHART_VERSION}.tgz spacelift
 
       - name: Package spacelift-workerpool-controller chart
         run: |
           helm package --version "$CHART_VERSION" --destination build/chart/spacelift-workerpool-controller/ spacelift-workerpool-controller
-          helm s3 push --relative build/chart/spacelift-workerpool-controller/spacelift-workerpool-controller-${CHART_VERSION}.tgz spacelift
+          helm s3 push --force --relative build/chart/spacelift-workerpool-controller/spacelift-workerpool-controller-${CHART_VERSION}.tgz spacelift
 
       - name: Invalidate cache
         run: >-


### PR DESCRIPTION
I need to re-run the action to publish v0.11.0 because it failed to publish the `spacelift-workerpool-controller` chart. But unfortunately it's now failing because the other two charts have already been published.

I've added the `--force` flag to allow us to overwrite the published version in this situation since it should only happen if we delete and re-tag a release, in which case we want to re-publish.