### PR TITLE
fix: fix kubelinter findings

### DIFF
--- a/spacelift-workerpool-controller/templates/deployment.yaml
+++ b/spacelift-workerpool-controller/templates/deployment.yaml
@@ -66,6 +66,13 @@ spec:
           value: {{ quote .Values.kubernetesClusterDomain }}
         image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag
           | default .Chart.AppVersion }}
+        ports:
+          - containerPort: 8081
+            name: health
+          {{- if .Values.metricsService.enabled }}
+          - containerPort: 8080
+            name: metrics
+          {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/spacelift-workerpool-controller/values.yaml
+++ b/spacelift-workerpool-controller/values.yaml
@@ -11,6 +11,7 @@ controllerManager:
     - --logtostderr=true
     - --v=0
     containerSecurityContext:
+      readOnlyRootFilesystem: true
       allowPrivilegeEscalation: false
       capabilities:
         drop:
@@ -30,6 +31,7 @@ controllerManager:
     - --health-probe-bind-address=:8081
     - --leader-elect
     containerSecurityContext:
+      readOnlyRootFilesystem: true
       allowPrivilegeEscalation: false
       capabilities:
         drop:


### PR DESCRIPTION
Follow up of https://github.com/spacelift-io/kube-workerpool-controller/pull/93, but for the Helm chart.

I tested manually the output when metrics server is enabled and disabled.
We should work on adding basic golden files tests to catch formatting issues like the indent issue with `---` we had before.