### PR TITLE
fix: don't deploy ClusterRole when metrics not enabled

### DIFF
--- a/spacelift-workerpool-controller/templates/proxy-rbac.yaml
+++ b/spacelift-workerpool-controller/templates/proxy-rbac.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.metricsService.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -38,3 +39,4 @@ subjects:
 - kind: ServiceAccount
   name: '{{ include "spacelift-workerpool-controller.fullname" . }}-controller-manager'
   namespace: '{{ .Release.Namespace }}'
+{{ end }}

--- a/spacelift-workerpool-controller/values.yaml
+++ b/spacelift-workerpool-controller/values.yaml
@@ -3,6 +3,10 @@ controllerManager:
   # and will be able to manage WorkerPools across all namespaces in your cluster.
   # If you do not want to grant cluster wide permissions to the controller, you can specify a list
   # of namespaces. That will create a Role per namespace and bind it to the service account used by the controller.
+  #
+  # PLEASE NOTE: currently the metrics service requires a ClusterRole in order to function, so
+  # if `metricsService.enabled` is set to true, a ClusterRole will be created even if you
+  # specify namespaces.
   namespaces: []
   kubeRbacProxy:
     args:


### PR DESCRIPTION
We were deploying the ClusterRole for kube-rbac-proxy even when the metrics server was not enabled. This doesn't make sense since the kube-rbac-proxy side-car container (and therefore the ClusterRole) are only used to implement authorization for accessing metrics.