### PR TITLE
feat: bump Kubernetes controller to v0.0.11

### DIFF
--- a/spacelift-workerpool-controller/Chart.yaml
+++ b/spacelift-workerpool-controller/Chart.yaml
@@ -3,4 +3,4 @@ name: spacelift-workerpool-controller
 description: A Helm chart for deploying spacelift workerpool controller
 type: application
 version: 0.1.0
-appVersion: "v0.0.10"
+appVersion: "v0.0.11"

--- a/spacelift-workerpool-controller/values.yaml
+++ b/spacelift-workerpool-controller/values.yaml
@@ -42,7 +42,7 @@ controllerManager:
         - ALL
     image:
       repository: public.ecr.aws/spacelift/kube-workerpool-controller
-      tag: v0.0.10
+      tag: v0.0.11
     resources:
       limits:
         memory: 128Mi


### PR DESCRIPTION
This is to include [a fix](https://github.com/spacelift-io/kube-workerpool-controller/pull/119) on the worker pool controller that was causing the MQTT client to be disconnected.

- [x] A chart version is updated
  - [x] No changes on CRDs
  - [ ] CRDs are updated
