### PR TITLE
fix(CU-8694xkz2b): remove usage of `Release.Service`

### DIFF
--- a/spacelift-workerpool-controller/templates/_helpers.tpl
+++ b/spacelift-workerpool-controller/templates/_helpers.tpl
@@ -39,7 +39,7 @@ helm.sh/chart: {{ include "spacelift-workerpool-controller.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/managed-by: Helm
 {{- end }}
 
 {{/*


### PR DESCRIPTION
Replace it with the default value `Helm` according to the doc https://helm.sh/docs/chart_template_guide/builtin_objects/

See action items in https://app.clickup.com/t/8694xkz2b for more context about this change.

- [ ] A chart version is updated
  - [ ] No changes on CRDs
  - [ ] CRDs are updated
