### PR TITLE
feat: bump Kubernetes controller to v0.0.12

### DIFF
--- a/spacelift-workerpool-controller/Chart.yaml
+++ b/spacelift-workerpool-controller/Chart.yaml
@@ -3,4 +3,4 @@ name: spacelift-workerpool-controller
 description: A Helm chart for deploying spacelift workerpool controller
 type: application
 version: 0.1.0
-appVersion: "v0.0.11"
+appVersion: "v0.0.12"

--- a/spacelift-workerpool-controller/values.yaml
+++ b/spacelift-workerpool-controller/values.yaml
@@ -42,7 +42,7 @@ controllerManager:
         - ALL
     image:
       repository: public.ecr.aws/spacelift/kube-workerpool-controller
-      tag: v0.0.11
+      tag: v0.0.12
     resources:
       limits:
         memory: 128Mi


### PR DESCRIPTION
This bumps the workerpool controller to `v0.0.12` to ship small improvements on error handling.

- [x] A chart version is updated
  - [x] No changes on CRDs
  - [ ] CRDs are updated
