### PR TITLE
Fix spacelift-promex readme

### DIFF
--- a/spacelift-promex/README.md
+++ b/spacelift-promex/README.md
@@ -19,9 +19,9 @@ kubectl create secret generic spacelift-api-key --from-literal=SPACELIFT_PROMEX_
 You can then install the controller using this chart
 ```shell
 helm upgrade spacelift-prometheus-exporter spacelift/spacelift-promex --install \
-    --set spacelift.apiEndpoint="https://{yourAccount}.app.spacelift.io" \
-    --set spacelift.apiKeyId="{yourApiToken}" \
-    --set spacelift.apiKeySecretName="spacelift-api-key"
+    --set apiEndpoint="https://{yourAccount}.app.spacelift.io" \
+    --set apiKeyId="{yourApiToken}" \
+    --set apiKeySecretName="spacelift-api-key"
 ```
 
 Follow the instructions on the [user-documentation](https://github.com/spacelift-io/prometheus-exporter) for more detailed instructions.


### PR DESCRIPTION
The readme for installing the promex exporter is slightly incorrect. Config values are prefixed with spacelift.

![image](https://github.com/user-attachments/assets/aba7d9c5-5510-4a48-aec3-62f0d52641b7)

