### PR TITLE
feat: support a more secure security-context

### DIFF
--- a/spacelift-promex/templates/deployment.yaml
+++ b/spacelift-promex/templates/deployment.yaml
@@ -40,6 +40,15 @@ spec:
           ports:
             - name: metrics
               containerPort: 9953
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            seccompProfile:
+              type: "RuntimeDefault"
+            runAsUser: 1983
           readinessProbe:
             httpGet:
               path: /health


### PR DESCRIPTION
Added a more secure/best practice security context to the promex container. It will allow customers to set the [Pod Security Policy to restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted).

- [x] A chart version is updated
  - [x] No changes on CRDs
  - [x] CRDs are updated