### PR TITLE
feat: add support for customBinariesPath to k8s controller

### DIFF
--- a/spacelift-workerpool-controller/Chart.yaml
+++ b/spacelift-workerpool-controller/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: spacelift-workerpool-controller
 description: A Helm chart for deploying spacelift workerpool controller
 type: application
-version: 0.2.0
-appVersion: "v0.0.14"
+version: 0.3.0
+appVersion: "v0.0.18"
 
 dependencies:
   - name: spacelift-promex

--- a/spacelift-workerpool-controller/crds/workerpool-crd.yaml
+++ b/spacelift-workerpool-controller/crds/workerpool-crd.yaml
@@ -1950,6 +1950,8 @@ spec:
                       required:
                         - name
                       type: object
+                    customBinariesPath:
+                      type: string
                     customInitContainers:
                       items:
                         properties:

--- a/spacelift-workerpool-controller/values.yaml
+++ b/spacelift-workerpool-controller/values.yaml
@@ -16,7 +16,7 @@ controllerManager:
         - ALL
     image:
       repository: public.ecr.aws/spacelift/kube-workerpool-controller
-      tag: v0.0.17
+      tag: v0.0.18
     resources:
       limits:
         memory: 128Mi


### PR DESCRIPTION
We've added a new `spec.pod.customBinariesPath` option to the WorkerPool resource that allows custom paths to be injected at the start of the path for workers.

- [x] A chart version is updated
  - [ ] No changes on CRDs
  - [x] CRDs are updated
