### PR TITLE
Support image pull secrets in workerpool controller

### DIFF
--- a/spacelift-workerpool-controller/Chart.yaml
+++ b/spacelift-workerpool-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: spacelift-workerpool-controller
 description: A Helm chart for deploying spacelift workerpool controller
 type: application
-version: 0.4.0
+version: 0.5.0
 appVersion: "v0.0.19"
 
 dependencies:

--- a/spacelift-workerpool-controller/Chart.yaml
+++ b/spacelift-workerpool-controller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: spacelift-workerpool-controller
 description: A Helm chart for deploying spacelift workerpool controller
 type: application
-version: 0.5.0
+version: 0.6.0
 appVersion: "v0.0.19"
 
 dependencies:

--- a/spacelift-workerpool-controller/templates/deployment.yaml
+++ b/spacelift-workerpool-controller/templates/deployment.yaml
@@ -36,6 +36,10 @@ spec:
                 operator: In
                 values:
                 - linux
+      {{- with .Values.controllerManager.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - args: {{- toYaml .Values.controllerManager.manager.args | nindent 8 }}
         {{- if .Values.metricsService.enabled }}

--- a/spacelift-workerpool-controller/values.yaml
+++ b/spacelift-workerpool-controller/values.yaml
@@ -31,6 +31,7 @@ controllerManager:
   nodeSelector: {}
   tolerations: []
   topologySpreadConstraints: []
+  imagePullSecrets: []
 kubernetesClusterDomain: cluster.local
 # The metric service will expose a metrics endpoint that can be scraped by a prometheus instance.
 # This is disabled by default, enable this if you want to enable controller observability.


### PR DESCRIPTION
- [x] A chart version is updated
  - [x] No changes on CRDs
  - [ ] CRDs are updated

Adds `imagePullSecrets` option to the `spacelift-workerpool-controller` chart to support pulling the mirrored image from the private registries.