### PR TITLE
feat: add self-hosted chart

### DIFF
--- a/.github/workflows/build-chart.yml
+++ b/.github/workflows/build-chart.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Lint spacelift-operator chart
         run: helm lint --strict spacelift-operator/
 
-      - name: Lint Spacelift VCS Agent chart
+      - name: Lint spacelift-self-hosted chart
         run: helm lint --strict spacelift-self-hosted/
 
       - name: Package Spacelift PromEx chart

--- a/.github/workflows/build-chart.yml
+++ b/.github/workflows/build-chart.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Create output directory for Spacelift VCS Agent Chart
         run: mkdir -p build/chart/vcs-agent
 
+      - name: Create output directory for Spacelift self hosted chart
+        run: mkdir -p build/chart/spacelift-self-hosted
+
       - name: Add the Spacelift Helm registry
         run: helm repo add spacelift s3://${{ secrets.PREPROD_AWS_S3_BUCKET }}/helm
         # The first time this step runs the index file won't exist, so allow the step to fail
@@ -75,6 +78,9 @@ jobs:
       - name: Lint spacelift-operator chart
         run: helm lint --strict spacelift-operator/
 
+      - name: Lint Spacelift VCS Agent chart
+        run: helm lint --strict spacelift-self-hosted/
+
       - name: Package Spacelift PromEx chart
         run: |
           helm package --version "$CHART_VERSION" --destination build/chart/spacelift-promex spacelift-promex/
@@ -94,3 +100,7 @@ jobs:
       - name: Package spacelift-operator chart
         run: |
           helm package --version "$CHART_VERSION" --destination build/chart/spacelift-operator spacelift-operator/
+
+      - name: Package spacelift-self-hosted chart
+        run: |
+          helm package --version "$CHART_VERSION" --destination build/chart/spacelift-self-hosted spacelift-self-hosted/

--- a/.github/workflows/chart-publish-preprod.yml
+++ b/.github/workflows/chart-publish-preprod.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Create output directory for spacelift-operator Chart
         run: mkdir -p build/chart/spacelift-operator
 
+      - name: Create output directory for spacelift-self-hosted chart
+        run: mkdir -p build/chart/spacelift-self-hosted
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -83,6 +86,9 @@ jobs:
       - name: Lint spacelift-operator chart
         run: helm lint spacelift-operator/
 
+      - name: Lint spacelift-self-hosted chart
+        run: helm lint --strict spacelift-self-hosted/
+
       - name: Package spacelift-promex chart
         run: |
           helm package --version "$CHART_VERSION" --destination build/chart/spacelift-promex spacelift-promex/
@@ -108,12 +114,17 @@ jobs:
           helm package --version "$CHART_VERSION" --destination build/chart/spacelift-operator spacelift-operator/
           helm s3 push --relative build/chart/spacelift-operator/spacelift-operator-${CHART_VERSION}.tgz spacelift
 
+      - name: Package spacelift-self-hosted chart
+        run: |
+          helm package --version "$CHART_VERSION" --destination build/chart/spacelift-self-hosted spacelift-self-hosted/
+          helm s3 push --relative build/chart/spacelift-self-hosted/spacelift-self-hosted-${CHART_VERSION}.tgz spacelift
+
       - name: Invalidate cache
         run: >-
           aws cloudfront create-invalidation
           --distribution-id ${{ secrets.PREPROD_DISTRIBUTION }}
           --paths "/helm/*"
-          
+
   test-new-version:
     name: Test that the new chart version can be pulled
     runs-on: ubuntu-latest
@@ -139,3 +150,4 @@ jobs:
           helm pull --devel spacelift/vcs-agent
           helm pull --devel spacelift/spacelift-workerpool-controller
           helm pull --devel spacelift/spacelift-operator
+          helm pull --devel spacelift/spacelift-self-hosted

--- a/.github/workflows/chart-publish-prod.yml
+++ b/.github/workflows/chart-publish-prod.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Create output directory for spacelift-operator Chart
         run: mkdir -p build/chart/spacelift-operator
 
+      - name: Create output directory for spacelift-self-hosted chart
+        run: mkdir -p build/chart/spacelift-self-hosted
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -86,6 +89,9 @@ jobs:
       - name: Lint spacelift-operator chart
         run: helm lint spacelift-operator/
 
+      - name: Lint spacelift-self-hosted chart
+        run: helm lint --strict spacelift-self-hosted/
+
       - name: Package Spacelift PromEx chart
         run: |
           helm package --version "$CHART_VERSION" --destination build/chart/spacelift-promex spacelift-promex/
@@ -111,12 +117,17 @@ jobs:
           helm package --version "$CHART_VERSION" --destination build/chart/spacelift-operator/ spacelift-operator
           helm s3 push --force --relative build/chart/spacelift-operator/spacelift-operator-${CHART_VERSION}.tgz spacelift
 
+      - name: Package spacelift-self-hosted chart
+        run: |
+          helm package --version "$CHART_VERSION" --destination build/chart/spacelift-self-hosted/ spacelift-self-hosted
+          helm s3 push --force --relative build/chart/spacelift-self-hosted/spacelift-self-hosted-${CHART_VERSION}.tgz spacelift
+
       - name: Invalidate cache
         run: >-
           aws cloudfront create-invalidation
           --distribution-id ${{ secrets.DISTRIBUTION }}
           --paths "/helm/*"
-          
+
   test-new-version:
     name: Test that the new chart version can be pulled
     runs-on: ubuntu-latest
@@ -141,3 +152,4 @@ jobs:
           helm pull spacelift/vcs-agent
           helm pull spacelift/spacelift-workerpool-controller
           helm pull spacelift/spacelift-operator
+          helm pull spacelift/spacelift-self-hosted

--- a/spacelift-self-hosted/.helmignore
+++ b/spacelift-self-hosted/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/spacelift-self-hosted/Chart.yaml
+++ b/spacelift-self-hosted/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: spacelift
+description: A Helm chart for deploying spacelift self-hosted
+type: application
+version: 0.1.0
+appVersion: "3.0.0"

--- a/spacelift-self-hosted/README.md
+++ b/spacelift-self-hosted/README.md
@@ -1,0 +1,8 @@
+# Helm chart spacelift-self-hosted
+
+This chart allows to deploy an instance of Spacelift in a self-hosted environment.
+
+## Quick Start
+
+Depending on your environment, you can check the [guides here](https://user-documentation-shv3.onrender.com/self-hosted/latest/installing-spacelift/reference-architecture/guides.html) 
+for more details about how to use this chart.

--- a/spacelift-self-hosted/templates/NOTES.txt
+++ b/spacelift-self-hosted/templates/NOTES.txt
@@ -1,0 +1,11 @@
+{{- if .Values.ingress.enabled }}
+1. Get the application URL by running this command:
+
+  kubectl get ingresses --namespace "{{ .Release.Namespace }}"
+{{- end }}
+
+{{- if eq .Values.mqttService.type "LoadBalancer" }}
+2. Get the MQTT service address by running this command:
+
+  kubectl get services --namespace "{{ .Release.Namespace }}" "{{ include "spacelift.fullname" . }}-mqtt"
+{{- end }}

--- a/spacelift-self-hosted/templates/_helpers.tpl
+++ b/spacelift-self-hosted/templates/_helpers.tpl
@@ -1,0 +1,149 @@
+{{/*
+Expand the name of the server.
+*/}}
+{{- define "spacelift.serverName" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "spacelift.drainName" -}}
+{{- printf "%s-drain" (default .Values.nameOverride .Chart.Name) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "spacelift.schedulerName" -}}
+{{- printf "%s-scheduler" (default .Values.nameOverride .Chart.Name) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "spacelift.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "spacelift.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Server labels
+*/}}
+{{- define "spacelift.serverLabels" -}}
+helm.sh/chart: {{ include "spacelift.chart" . }}
+{{ include "spacelift.serverSelectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Common drain labels
+*/}}
+{{- define "spacelift.drainLabels" -}}
+helm.sh/chart: {{ include "spacelift.chart" . }}
+{{ include "spacelift.drainSelectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Common scheduler labels
+*/}}
+{{- define "spacelift.schedulerLabels" -}}
+helm.sh/chart: {{ include "spacelift.chart" . }}
+{{ include "spacelift.schedulerSelectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Server Selector labels
+*/}}
+{{- define "spacelift.serverSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "spacelift.serverName" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Selector drain labels
+*/}}
+{{- define "spacelift.drainSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "spacelift.drainName" . }}
+app.kubernetes.io/instance: {{ printf "%s-drain" .Release.Name }}
+{{- end }}
+
+{{/*
+Selector scheduler labels
+*/}}
+{{- define "spacelift.schedulerSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "spacelift.schedulerName" . }}
+app.kubernetes.io/instance: {{ printf "%s-scheduler" .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "spacelift.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "spacelift.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use for the server.
+*/}}
+{{- define "spacelift.serverServiceAccountName" -}}
+{{- if .Values.server.serviceAccount.create }}
+{{- .Values.server.serviceAccount.name }}
+{{- else }}
+{{- include "spacelift.serviceAccountName" . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use for the drain.
+*/}}
+{{- define "spacelift.drainServiceAccountName" -}}
+{{- if .Values.drain.serviceAccount.create }}
+{{- .Values.drain.serviceAccount.name }}
+{{- else }}
+{{- include "spacelift.serviceAccountName" . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use for the scheduler.
+*/}}
+{{- define "spacelift.schedulerServiceAccountName" -}}
+{{- if .Values.scheduler.serviceAccount.create }}
+{{- .Values.scheduler.serviceAccount.name }}
+{{- else }}
+{{- include "spacelift.serviceAccountName" . }}
+{{- end }}
+{{- end }}

--- a/spacelift-self-hosted/templates/drain-deployment.yaml
+++ b/spacelift-self-hosted/templates/drain-deployment.yaml
@@ -1,0 +1,148 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "spacelift.fullname" . }}-drain
+  labels:
+    {{- include "spacelift.drainLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.drain.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "spacelift.drainSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.drain.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "spacelift.drainLabels" . | nindent 8 }}
+        {{- with .Values.drain.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "spacelift.drainServiceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.drain.podSecurityContext | nindent 8 }}
+      {{- if .Values.cloudSqlProxy.enabled }}
+      initContainers:
+        - name: cloud-sql-proxy
+          image: {{ .Values.cloudSqlProxy.image }}
+          restartPolicy: Always
+          env:
+            # Enable HTTP healthchecks on port 9801. This enables /liveness,
+            # /readiness and /startup health check endpoints. Allow connections
+            # listen for connections on any interface (0.0.0.0) so that the
+            # k8s management components can reach these endpoints.
+            - name: CSQL_PROXY_HEALTH_CHECK
+              value: "true"
+            - name: CSQL_PROXY_HTTP_PORT
+              value: "9801"
+            - name: CSQL_PROXY_HTTP_ADDRESS
+              value: 0.0.0.0
+          args:
+            - "--private-ip"
+            - "--structured-logs"
+            - "--port=5432"
+            - "--auto-iam-authn"
+            - "{{ .Values.cloudSqlProxy.dbConnectionName }}"
+          ports:
+            - containerPort: 9801
+              protocol: TCP
+          # The /startup probe returns OK when the proxy is ready to receive
+          # connections from the application. In this example, k8s will check
+          # once a second for 60 seconds.
+          #
+          # We strongly recommend adding a startup probe to the proxy sidecar
+          # container. This will ensure that service traffic will be routed to
+          # the pod only after the proxy has successfully started.
+          startupProbe:
+            failureThreshold: 60
+            httpGet:
+              path: /startup
+              port: 9801
+              scheme: HTTP
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 10
+          # The /liveness probe returns OK as soon as the proxy application has
+          # begun its startup process and continues to return OK until the
+          # process stops.
+          #
+          # We recommend adding a liveness probe to the proxy sidecar container.
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /liveness
+              port: 9801
+              scheme: HTTP
+            # The probe will be checked every 10 seconds.
+            periodSeconds: 10
+            # Number of times the probe is allowed to fail before the transition
+            # from healthy to failure state.
+            #
+            # If periodSeconds = 60, 5 tries will result in five minutes of
+            # checks. The proxy starts to refresh a certificate five minutes
+            # before its expiration. If those five minutes lapse without a
+            # successful refresh, the liveness probe will fail and the pod will be
+            # restarted.
+            successThreshold: 1
+            # The probe will fail if it does not respond in 10 seconds
+            timeoutSeconds: 10
+          securityContext:
+            # The default Cloud SQL Auth Proxy image runs as the
+            # "nonroot" user and group (uid: 65532) by default.
+            runAsNonRoot: true
+            # Use a read-only filesystem
+            readOnlyRootFilesystem: true
+            # Do not allow privilege escalation
+            allowPrivilegeEscalation: false
+          resources:
+            {{- toYaml .Values.cloudSqlProxy.resources | nindent 12 }}
+      {{- end }}
+      containers:
+        - name: drain
+          securityContext:
+            {{- toYaml .Values.drain.securityContext | nindent 12 }}
+          image: "{{ .Values.shared.image }}"
+          imagePullPolicy: {{ .Values.drain.pullPolicy }}
+          command:
+            - spacelift
+            - backend
+            - drain-local
+          env:
+            - name: ENABLE_INSTRUMENTATION_ENDPOINTS
+              value: "true"
+          envFrom:
+            - secretRef:
+                name: {{ .Values.shared.secretRef }}
+            - secretRef:
+                name: {{ .Values.drain.secretRef }}
+          ports:
+            - name: instrumentation
+              containerPort: 8080
+              protocol: TCP
+          startupProbe:
+            {{- toYaml .Values.drain.startupProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.drain.resources | nindent 12 }}
+          {{- with .Values.drain.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.drain.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.drain.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.drain.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.drain.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/spacelift-self-hosted/templates/drain-serviceaccount.yaml
+++ b/spacelift-self-hosted/templates/drain-serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.drain.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "spacelift.drainServiceAccountName" . }}
+  labels:
+    {{- include "spacelift.drainLabels" . | nindent 4 }}
+  {{- with .Values.drain.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.drain.serviceAccount.automount }}
+{{- end }}

--- a/spacelift-self-hosted/templates/ingress-v6.yaml
+++ b/spacelift-self-hosted/templates/ingress-v6.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.ingressV6.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: server-v6
+  labels:
+    {{- include "spacelift.serverLabels" . | nindent 4 }}
+  {{- with .Values.ingressV6.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  tls:
+    - hosts:
+        - {{ .Values.shared.serverHostname }}
+      secretName: cert
+  rules:
+    - host: {{ .Values.shared.serverHostname }}
+      http:
+        paths:
+          - path: /*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ include "spacelift.fullname" $ }}-server
+                port:
+                  name: server
+{{- end }}

--- a/spacelift-self-hosted/templates/ingress.yaml
+++ b/spacelift-self-hosted/templates/ingress.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: server-v4
+  labels:
+    {{- include "spacelift.serverLabels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  tls:
+    - hosts:
+        - {{ .Values.shared.serverHostname }}
+      secretName: cert
+  rules:
+    - host: {{ .Values.shared.serverHostname }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "spacelift.fullname" $ }}-server
+                port:
+                  name: server
+{{- end }}

--- a/spacelift-self-hosted/templates/mqtt-service.yaml
+++ b/spacelift-self-hosted/templates/mqtt-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "spacelift.fullname" . }}-mqtt
+  {{- with .Values.mqttService.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "spacelift.serverLabels" . | nindent 4 }}
+spec:
+  type: {{ .Values.mqttService.type }}
+  {{- with .Values.mqttService.additionalSpec }}
+    {{- toYaml . | nindent 2}}
+  {{- end }}
+  ports:
+    - port: {{ .Values.mqttService.port }}
+      targetPort: mqtt
+      protocol: TCP
+      name: server
+  selector:
+    {{- include "spacelift.serverSelectorLabels" . | nindent 4 }}

--- a/spacelift-self-hosted/templates/scheduler-deployment.yaml
+++ b/spacelift-self-hosted/templates/scheduler-deployment.yaml
@@ -1,0 +1,145 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "spacelift.fullname" . }}-scheduler
+  labels:
+    {{- include "spacelift.schedulerLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.scheduler.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "spacelift.schedulerSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.scheduler.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "spacelift.schedulerLabels" . | nindent 8 }}
+        {{- with .Values.scheduler.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "spacelift.schedulerServiceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.scheduler.podSecurityContext | nindent 8 }}
+      {{- if .Values.cloudSqlProxy.enabled }}
+      initContainers:
+        - name: cloud-sql-proxy
+          image: {{ .Values.cloudSqlProxy.image }}
+          restartPolicy: Always
+          env:
+            # Enable HTTP healthchecks on port 9801. This enables /liveness,
+            # /readiness and /startup health check endpoints. Allow connections
+            # listen for connections on any interface (0.0.0.0) so that the
+            # k8s management components can reach these endpoints.
+            - name: CSQL_PROXY_HEALTH_CHECK
+              value: "true"
+            - name: CSQL_PROXY_HTTP_PORT
+              value: "9801"
+            - name: CSQL_PROXY_HTTP_ADDRESS
+              value: 0.0.0.0
+          args:
+            - "--private-ip"
+            - "--structured-logs"
+            - "--port=5432"
+            - "--auto-iam-authn"
+            - "{{ .Values.cloudSqlProxy.dbConnectionName }}"
+          ports:
+            - containerPort: 9801
+              protocol: TCP
+          # The /startup probe returns OK when the proxy is ready to receive
+          # connections from the application. In this example, k8s will check
+          # once a second for 60 seconds.
+          #
+          # We strongly recommend adding a startup probe to the proxy sidecar
+          # container. This will ensure that service traffic will be routed to
+          # the pod only after the proxy has successfully started.
+          startupProbe:
+            failureThreshold: 60
+            httpGet:
+              path: /startup
+              port: 9801
+              scheme: HTTP
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 10
+          # The /liveness probe returns OK as soon as the proxy application has
+          # begun its startup process and continues to return OK until the
+          # process stops.
+          #
+          # We recommend adding a liveness probe to the proxy sidecar container.
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /liveness
+              port: 9801
+              scheme: HTTP
+            # The probe will be checked every 10 seconds.
+            periodSeconds: 10
+            # Number of times the probe is allowed to fail before the transition
+            # from healthy to failure state.
+            #
+            # If periodSeconds = 60, 5 tries will result in five minutes of
+            # checks. The proxy starts to refresh a certificate five minutes
+            # before its expiration. If those five minutes lapse without a
+            # successful refresh, the liveness probe will fail and the pod will be
+            # restarted.
+            successThreshold: 1
+            # The probe will fail if it does not respond in 10 seconds
+            timeoutSeconds: 10
+          securityContext:
+            # The default Cloud SQL Auth Proxy image runs as the
+            # "nonroot" user and group (uid: 65532) by default.
+            runAsNonRoot: true
+            # Use a read-only filesystem
+            readOnlyRootFilesystem: true
+            # Do not allow privilege escalation
+            allowPrivilegeEscalation: false
+          resources:
+            {{- toYaml .Values.cloudSqlProxy.resources | nindent 12 }}
+      {{- end }}
+      containers:
+        - name: scheduler
+          securityContext:
+            {{- toYaml .Values.scheduler.securityContext | nindent 12 }}
+          image: "{{ .Values.shared.image }}"
+          imagePullPolicy: {{ .Values.scheduler.pullPolicy }}
+          command:
+            - spacelift
+            - scheduler
+          env:
+            - name: ENABLE_INSTRUMENTATION_ENDPOINTS
+              value: "true"
+          envFrom:
+            - secretRef:
+                name: {{ .Values.shared.secretRef }}
+          ports:
+            - name: instrumentation
+              containerPort: 8080
+              protocol: TCP
+          startupProbe:
+            {{- toYaml .Values.scheduler.startupProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.scheduler.resources | nindent 12 }}
+          {{- with .Values.scheduler.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.scheduler.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.scheduler.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.scheduler.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.scheduler.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/spacelift-self-hosted/templates/scheduler-serviceaccount.yaml
+++ b/spacelift-self-hosted/templates/scheduler-serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.scheduler.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "spacelift.schedulerServiceAccountName" . }}
+  labels:
+    {{- include "spacelift.schedulerLabels" . | nindent 4 }}
+  {{- with .Values.scheduler.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.scheduler.serviceAccount.automount }}
+{{- end }}

--- a/spacelift-self-hosted/templates/server-deployment.yaml
+++ b/spacelift-self-hosted/templates/server-deployment.yaml
@@ -1,0 +1,169 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "spacelift.fullname" . }}-server
+  labels:
+    {{- include "spacelift.serverLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.server.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # We wanted to avoid a situation where the deployment allocates an additional pod.
+      # The reason for that is that we wanted to avoid the cluster to have to spawn a new node
+      # just to be able to schedule temporary workload.
+      # Since we use autopilot, the control plane tendency is to allocate just what is required for running
+      # the actual workload, and thus there is a chance that increasing the maxSurge will trigger a new node to be spawned.
+      # The only thing I wanted to do here to speed up a bit the deployment is increase the number of pod that can
+      # be terminated at the same time. Because previously, it was 1.
+      # This is probably not the best for a production environment.
+      maxSurge: 0
+      maxUnavailable: 90%
+  selector:
+    matchLabels:
+      {{- include "spacelift.serverSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.server.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "spacelift.serverLabels" . | nindent 8 }}
+        {{- with .Values.server.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "spacelift.serverServiceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.server.podSecurityContext | nindent 8 }}
+      {{- if .Values.cloudSqlProxy.enabled }}
+      initContainers:
+        - name: cloud-sql-proxy
+          image: {{ .Values.cloudSqlProxy.image }}
+          restartPolicy: Always
+          env:
+          # Enable HTTP healthchecks on port 9801. This enables /liveness,
+          # /readiness and /startup health check endpoints. Allow connections
+          # listen for connections on any interface (0.0.0.0) so that the
+          # k8s management components can reach these endpoints.
+          - name: CSQL_PROXY_HEALTH_CHECK
+            value: "true"
+          - name: CSQL_PROXY_HTTP_PORT
+            value: "9801"
+          - name: CSQL_PROXY_HTTP_ADDRESS
+            value: 0.0.0.0
+          args:
+            - "--private-ip"
+            - "--structured-logs"
+            - "--port=5432"
+            - "--auto-iam-authn"
+            - "{{ .Values.cloudSqlProxy.dbConnectionName }}"
+          ports:
+            - containerPort: 9801
+              protocol: TCP
+          # The /startup probe returns OK when the proxy is ready to receive
+          # connections from the application. In this example, k8s will check
+          # once a second for 60 seconds.
+          #
+          # We strongly recommend adding a startup probe to the proxy sidecar
+          # container. This will ensure that service traffic will be routed to
+          # the pod only after the proxy has successfully started.
+          startupProbe:
+            failureThreshold: 60
+            httpGet:
+              path: /startup
+              port: 9801
+              scheme: HTTP
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 10
+          # The /liveness probe returns OK as soon as the proxy application has
+          # begun its startup process and continues to return OK until the
+          # process stops.
+          #
+          # We recommend adding a liveness probe to the proxy sidecar container.
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /liveness
+              port: 9801
+              scheme: HTTP
+            # The probe will be checked every 10 seconds.
+            periodSeconds: 10
+            # Number of times the probe is allowed to fail before the transition
+            # from healthy to failure state.
+            #
+            # If periodSeconds = 60, 5 tries will result in five minutes of
+            # checks. The proxy starts to refresh a certificate five minutes
+            # before its expiration. If those five minutes lapse without a
+            # successful refresh, the liveness probe will fail and the pod will be
+            # restarted.
+            successThreshold: 1
+            # The probe will fail if it does not respond in 10 seconds
+            timeoutSeconds: 10
+          securityContext:
+            # The default Cloud SQL Auth Proxy image runs as the
+            # "nonroot" user and group (uid: 65532) by default.
+            runAsNonRoot: true
+            # Use a read-only filesystem
+            readOnlyRootFilesystem: true
+            # Do not allow privilege escalation
+            allowPrivilegeEscalation : false
+          resources:
+            {{- toYaml .Values.cloudSqlProxy.resources | nindent 12 }}
+      {{- end }}
+      containers:
+        - name: server
+          securityContext:
+            {{- toYaml .Values.server.securityContext | nindent 12 }}
+          image: "{{ .Values.shared.image }}"
+          imagePullPolicy: {{ .Values.server.pullPolicy }}
+          command:
+            - spacelift
+            - backend
+            - server
+          env:
+            - name: ENABLE_INSTRUMENTATION_ENDPOINTS
+              value: "true"
+            - name: FEATURE_FLAG_SELF_HOSTED_V3_INSTALLATION_FLOW
+              value: "true"
+          envFrom:
+            - secretRef:
+                name: {{ .Values.shared.secretRef }}
+            - secretRef:
+                name: {{ .Values.server.secretRef }}
+          ports:
+            - name: server
+              containerPort: {{ .Values.server.port }}
+              protocol: TCP
+            - name: mqtt
+              containerPort: {{ .Values.server.mqttPort }}
+              protocol: TCP
+            - name: instrumentation
+              containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            {{- toYaml .Values.server.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.server.resources | nindent 12 }}
+          {{- with .Values.server.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.server.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/spacelift-self-hosted/templates/server-serviceaccount.yaml
+++ b/spacelift-self-hosted/templates/server-serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.server.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "spacelift.serverServiceAccountName" . }}
+  labels:
+    {{- include "spacelift.serverLabels" . | nindent 4 }}
+  {{- with .Values.server.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.server.serviceAccount.automount }}
+{{- end }}

--- a/spacelift-self-hosted/templates/service.yaml
+++ b/spacelift-self-hosted/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "spacelift.fullname" . }}-server
+  labels:
+    {{- include "spacelift.serverLabels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: server
+      protocol: TCP
+      name: server
+  selector:
+    {{- include "spacelift.serverSelectorLabels" . | nindent 4 }}

--- a/spacelift-self-hosted/templates/serviceaccount.yaml
+++ b/spacelift-self-hosted/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "spacelift.serviceAccountName" . }}
+  labels:
+    {{- include "spacelift.serverLabels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/spacelift-self-hosted/values.yaml
+++ b/spacelift-self-hosted/values.yaml
@@ -1,0 +1,134 @@
+shared:
+  secretRef:
+  image:
+  serverHostname:
+
+server:
+  replicaCount: 3
+  port: 1983
+  secretRef:
+  mqttPort: 1984
+  pullPolicy: Always
+  securityContext:
+  # TODO Make sure we can run the image as non root user
+  #  runAsNonRoot: true
+    allowPrivilegeEscalation : false
+  resources:
+    requests:
+      memory: "200Mi"
+      cpu: "200m"
+  readinessProbe:
+    httpGet:
+      path: /readiness
+      port: instrumentation
+  podLabels: {}
+  podSecurityContext: {}
+  volumes: []
+  volumeMounts: []
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  # serviceAccount controls whether an individual service account should be created for the server.
+  # If create is set to true, a name must be specified.
+  serviceAccount:
+    create: false
+    name: "spacelift-server"
+    automount: true
+    annotations: {}
+
+drain:
+  replicaCount: 3
+  secretRef:
+  pullPolicy: Always
+  securityContext:
+  # TODO Make sure we can run the image as non root user
+  #  runAsNonRoot: true
+    allowPrivilegeEscalation : false
+  resources:
+    requests:
+      memory: "100Mi"
+      cpu: "100m"
+  startupProbe:
+    httpGet:
+      path: /startup
+      port: instrumentation
+  podLabels: {}
+  podSecurityContext: {}
+  volumes: []
+  volumeMounts: []
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  # serviceAccount controls whether an individual service account should be created for the drain.
+  # If create is set to true, a name must be specified.
+  serviceAccount:
+    create: false
+    name: "spacelift-drain"
+    automount: true
+    annotations: {}
+
+scheduler:
+  replicaCount: 3
+  pullPolicy: Always
+  securityContext:
+  # TODO Make sure we can run the image as non root user
+  #  runAsNonRoot: true
+    allowPrivilegeEscalation : false
+  resources:
+    requests:
+      memory: "50Mi"
+      cpu: "50m"
+  startupProbe:
+    httpGet:
+      path: /startup
+      port: instrumentation
+  podLabels: {}
+  podSecurityContext: {}
+  volumes: []
+  volumeMounts: []
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  # serviceAccount controls whether an individual service account should be created for the scheduler.
+  # If create is set to true, a name must be specified.
+  serviceAccount:
+    create: false
+    name: "spacelift-scheduler"
+    automount: true
+    annotations: {}
+
+cloudSqlProxy:
+  enabled: false
+  image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.11.4
+  dbConnectionName:
+  resources:
+    requests:
+      memory: "200Mi"
+      cpu:    "100m"
+
+# Whether to create a single service account that all the services should use.
+serviceAccount:
+  create: true
+  name: "spacelift-backend"
+  automount: true
+  annotations: {}
+
+service:
+  type: ClusterIP
+  port: 80
+
+mqttService:
+  type: ClusterIP
+  port: 1984
+  annotations: {}
+
+ingress:
+  enabled: true
+  ingressClassName: ""
+  annotations: {}
+
+ingressV6:
+  enabled: true
+
+nameOverride: ""
+fullnameOverride: ""


### PR DESCRIPTION
This is just a copy and paste of the chart that is currently in our self-hosted repository. No changes.
I just added a readme with a link to the docs, and I'll update it once our doc is fully merged with mainstream.
Once the chart is deployed, I'll also update the docs.

- [ ] A chart version is updated
  - [ ] No changes on CRDs
  - [ ] CRDs are updated
