### PR TITLE
feat: simplify the server and mqtt broker service names

### DIFF
--- a/spacelift-self-hosted/templates/mqtt-service.yaml
+++ b/spacelift-self-hosted/templates/mqtt-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "spacelift.fullname" . }}-mqtt
+  name: {{ .Values.mqttService.name }}
   {{- with .Values.mqttService.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/spacelift-self-hosted/templates/service.yaml
+++ b/spacelift-self-hosted/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "spacelift.fullname" . }}-server
+  name: {{ .Values.service.name }}
   labels:
     {{- include "spacelift.serverLabels" . | nindent 4 }}
 spec:

--- a/spacelift-self-hosted/values.yaml
+++ b/spacelift-self-hosted/values.yaml
@@ -114,10 +114,12 @@ serviceAccount:
   annotations: {}
 
 service:
+  name: "spacelift-server"
   type: ClusterIP
   port: 80
 
 mqttService:
+  name: "spacelift-mqtt"
   type: ClusterIP
   port: 1984
   annotations: {}


### PR DESCRIPTION
We were using the default Helm approach of using the release name as a prefix to the service. But that makes things tricky because we need to pass the name of the MQTT service into an env var.

To make things a bit simpler, I've changed them to use properties from the values files with defaults. That means by default we always use `spacelift-server` and `spacelift-mqtt`, but it's still configurable if required.

- [ ] A chart version is updated
  - [ ] No changes on CRDs
  - [ ] CRDs are updated
