### PR TITLE
fix: adjust Self-Hosted ingresses to reference server correctly

### DIFF
--- a/spacelift-self-hosted/templates/ingress-v6.yaml
+++ b/spacelift-self-hosted/templates/ingress-v6.yaml
@@ -22,7 +22,7 @@ spec:
             pathType: ImplementationSpecific
             backend:
               service:
-                name: {{ include "spacelift.fullname" $ }}-server
+                name: {{ .Values.service.name }}
                 port:
                   name: server
 {{- end }}

--- a/spacelift-self-hosted/templates/ingress.yaml
+++ b/spacelift-self-hosted/templates/ingress.yaml
@@ -25,7 +25,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ include "spacelift.fullname" $ }}-server
+                name: {{ .Values.service.name }}
                 port:
                   name: server
 {{- end }}


### PR DESCRIPTION
When I adjusted the service name in my previous commit, I forgot that the ingresses would be referencing the service.

- [ ] A chart version is updated
  - [ ] No changes on CRDs
  - [ ] CRDs are updated
