### PR TITLE
fix: set fullnameOverride by default for self-hosted chart

### DIFF
--- a/spacelift-self-hosted/templates/mqtt-service.yaml
+++ b/spacelift-self-hosted/templates/mqtt-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.mqttService.name }}
+  name: {{ include "spacelift.fullname" . }}-mqtt
   {{- with .Values.mqttService.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/spacelift-self-hosted/templates/service.yaml
+++ b/spacelift-self-hosted/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.service.name }}
+  name: {{ include "spacelift.fullname" . }}-server
   labels:
     {{- include "spacelift.serverLabels" . | nindent 4 }}
 spec:

--- a/spacelift-self-hosted/values.yaml
+++ b/spacelift-self-hosted/values.yaml
@@ -114,12 +114,10 @@ serviceAccount:
   annotations: {}
 
 service:
-  name: "spacelift-server"
   type: ClusterIP
   port: 80
 
 mqttService:
-  name: "spacelift-mqtt"
   type: ClusterIP
   port: 1984
   annotations: {}
@@ -133,4 +131,4 @@ ingressV6:
   enabled: true
 
 nameOverride: ""
-fullnameOverride: ""
+fullnameOverride: "spacelift"


### PR DESCRIPTION
My previous change ended up breaking the Ingress definitions because I hadn't updated them to reference the new service name. Instead I'm taking a simpler approach of just setting the `fullnameOverride` to `spacelift` by default. This will have the same effect of being backwards compatible with our existing installations, but is a little simpler.

- [ ] A chart version is updated
  - [ ] No changes on CRDs
  - [ ] CRDs are updated
