### PR TITLE
feat: add missing nodeSelector to spacelift-promex

### DIFF
--- a/spacelift-promex/Chart.yaml
+++ b/spacelift-promex/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: spacelift-promex
 description: A Helm chart for deploying the Spacelift Prometheus exporter.
 type: application
-version: 0.0.2
+version: 0.0.3
 appVersion: "v0.3.1"

--- a/spacelift-promex/templates/deployment.yaml
+++ b/spacelift-promex/templates/deployment.yaml
@@ -29,6 +29,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: spacelift-promex
           {{- if .Values.image.digest }}

--- a/spacelift-promex/values.yaml
+++ b/spacelift-promex/values.yaml
@@ -29,3 +29,10 @@ annotations:
 #
 ## your api key secret, the secret should contain the key "SPACELIFT_PROMEX_API_KEY_SECRET"
 #apiKeySecretName: ""
+#
+# nodeSelector allows you to schedule pods on specific nodes.
+# Uncomment and modify the following lines to use it.
+# nodeSelector:
+#   kubernetes.io/arch: amd64
+#   disktype: ssd
+nodeSelector: {}


### PR DESCRIPTION
Updated Helm chart `spacelift-promex` to support configuring `nodeSelector`, which was missing for this Chart.
The change aligns with all other charts, which already supported this parameter.

Also updated Chart version from `0.0.2` to `0.0.3`.
Unchanged `appVersion`.
