### PR TITLE
chore: Bump promex version in workerpool-controller

### DIFF
--- a/spacelift-workerpool-controller/Chart.yaml
+++ b/spacelift-workerpool-controller/Chart.yaml
@@ -7,6 +7,6 @@ appVersion: "v0.0.25"
 
 dependencies:
   - name: spacelift-promex
-    version: 0.29.0
+    version: 0.47.0
     repository: "https://downloads.spacelift.io/helm"
     condition: spacelift-promex.enabled


### PR DESCRIPTION
Bump promex chart version in workerpool controller to contain all recent changes
Connected with #106
