### PR TITLE
feat(self-hosted): deploy the standalone scheduler only below app v6.4.0

### DIFF
--- a/spacelift-self-hosted/README.md
+++ b/spacelift-self-hosted/README.md
@@ -5,9 +5,10 @@ This chart allows to deploy an instance of Spacelift in a self-hosted environmen
 > [!NOTE]
 > From Spacelift v6.4.0 on, the drain runs the cron scheduler itself and this chart
 > no longer deploys a standalone `scheduler` workload. On older versions the workload
-> is still deployed, so upgrading the chart on its own is safe. There is nothing to
-> configure either way: the version is taken from the tag of `shared.image`. If that
-> tag is not of the form `vX.Y.Z`, the chart keeps deploying the workload.
+> is still deployed, so upgrading the chart on its own is safe. Normally there is
+> nothing to configure: the version is taken from the tag of `shared.image`, and if
+> that tag is not of the form `vX.Y.Z` the chart keeps deploying the workload. Set
+> `scheduler.enabled` to `true` or `false` to decide it yourself instead.
 
 ## Quick Start
 

--- a/spacelift-self-hosted/README.md
+++ b/spacelift-self-hosted/README.md
@@ -2,6 +2,13 @@
 
 This chart allows to deploy an instance of Spacelift in a self-hosted environment.
 
+> [!NOTE]
+> From Spacelift v6.4.0 on, the drain runs the cron scheduler itself and this chart
+> no longer deploys a standalone `scheduler` workload. On older versions the workload
+> is still deployed, so upgrading the chart on its own is safe. There is nothing to
+> configure either way: the version is taken from the tag of `shared.image`. If that
+> tag is not of the form `vX.Y.Z`, the chart keeps deploying the workload.
+
 ## Quick Start
 
 Depending on your environment, you can check the [guides here](https://docs.spacelift.io/self-hosted/latest/installing-spacelift/reference-architecture/guides) 

--- a/spacelift-self-hosted/templates/NOTES.txt
+++ b/spacelift-self-hosted/templates/NOTES.txt
@@ -9,3 +9,20 @@
 
   kubectl get services --namespace "{{ .Release.Namespace }}" "{{ include "spacelift.fullname" . }}-mqtt"
 {{- end }}
+
+{{- $core := include "spacelift.appVersionCore" . }}
+{{- if include "spacelift.deployStandaloneScheduler" . }}
+{{- if $core }}
+
+NOTE: this installation runs Spacelift {{ $core }}, which is older than v6.4.0, so
+the standalone "scheduler" workload is still deployed. From v6.4.0 on the drain
+runs the cron scheduler itself and this chart stops deploying the workload, with
+no action needed on your side.
+{{- else }}
+
+WARNING: no Spacelift version could be read from shared.image
+({{ .Values.shared.image | default "not set" | quote }}), so this chart is keeping the
+standalone "scheduler" workload to be safe. Use an image tag of the form vX.Y.Z if
+you want the workload to be removed automatically once you reach v6.4.0.
+{{- end }}
+{{- end }}

--- a/spacelift-self-hosted/templates/NOTES.txt
+++ b/spacelift-self-hosted/templates/NOTES.txt
@@ -11,8 +11,13 @@
 {{- end }}
 
 {{- $core := include "spacelift.appVersionCore" . }}
+{{- $forced := not (kindIs "invalid" .Values.scheduler.enabled) }}
 {{- if include "spacelift.deployStandaloneScheduler" . }}
-{{- if $core }}
+{{- if $forced }}
+
+NOTE: the standalone "scheduler" workload is deployed because scheduler.enabled is
+set to true. Unset it to let the chart decide from the application version instead.
+{{- else if $core }}
 
 NOTE: this installation runs Spacelift {{ $core }}, which is older than v6.4.0, so
 the standalone "scheduler" workload is still deployed. From v6.4.0 on the drain
@@ -22,7 +27,14 @@ no action needed on your side.
 
 WARNING: no Spacelift version could be read from shared.image
 ({{ .Values.shared.image | default "not set" | quote }}), so this chart is keeping the
-standalone "scheduler" workload to be safe. Use an image tag of the form vX.Y.Z if
-you want the workload to be removed automatically once you reach v6.4.0.
+standalone "scheduler" workload to be safe. Use an image tag of the form vX.Y.Z, or
+set scheduler.enabled explicitly, to decide this yourself.
 {{- end }}
+{{- else if and $forced $core (semverCompare "<6.4.0" $core) }}
+
+WARNING: the standalone "scheduler" workload is not deployed because
+scheduler.enabled is set to false, but this installation runs Spacelift {{ $core }},
+which does not run the cron scheduler in the drain. Nothing will trigger recurring
+work - drift detection, scheduled runs, tasks and deletes - until you upgrade to
+v6.4.0 or set scheduler.enabled back to true.
 {{- end }}

--- a/spacelift-self-hosted/templates/_helpers.tpl
+++ b/spacelift-self-hosted/templates/_helpers.tpl
@@ -139,17 +139,10 @@ Create the name of the service account to use for the drain.
 
 {{/*
 Create the name of the service account to use for the scheduler.
-Falls back to the drain's service account when the scheduler has none of its own
-but the drain does. This is the case on installations whose infrastructure module
-already stopped provisioning a scheduler service account, while the application
-is still old enough to need the standalone scheduler. The drain's permissions are
-a superset of the scheduler's, so it is a safe identity to borrow.
 */}}
 {{- define "spacelift.schedulerServiceAccountName" -}}
 {{- if .Values.scheduler.serviceAccount.create }}
 {{- .Values.scheduler.serviceAccount.name }}
-{{- else if .Values.drain.serviceAccount.create }}
-{{- .Values.drain.serviceAccount.name }}
 {{- else }}
 {{- include "spacelift.serviceAccountName" . }}
 {{- end }}

--- a/spacelift-self-hosted/templates/_helpers.tpl
+++ b/spacelift-self-hosted/templates/_helpers.tpl
@@ -159,8 +159,7 @@ a superset of the scheduler's, so it is a safe identity to borrow.
 The application version, taken from the tag of .Values.shared.image.
 
 Returns the "X.Y.Z" core of the tag, or an empty string when there is no tag or
-the tag is not a version at all. Released versions are always a plain vX.Y.Z, so
-anything else is a development build, which is newer than every release.
+the tag is not of the form vX.Y.Z. What an empty result means is up to the caller.
 */}}
 {{- define "spacelift.appVersionCore" -}}
 {{- $ref := .Values.shared.image | default "" -}}
@@ -176,6 +175,9 @@ anything else is a development build, which is newer than every release.
 {{/*
 Whether the standalone scheduler workload still has to be deployed.
 
+An explicit .Values.scheduler.enabled decides on its own, in both directions. Left
+unset (null), the chart works it out from the application version instead.
+
 From application v6.4.0 on, the drain always runs the cron scheduler itself, so a
 separate scheduler workload is redundant. Below that it is required, and so is
 the case where the version cannot be read: the scheduler is kept, because losing
@@ -183,8 +185,12 @@ it on an application that does not schedule on its own would silently stop all
 recurring work.
 */}}
 {{- define "spacelift.deployStandaloneScheduler" -}}
+{{- if not (kindIs "invalid" .Values.scheduler.enabled) -}}
+{{- if .Values.scheduler.enabled -}}true{{- end -}}
+{{- else -}}
 {{- $core := include "spacelift.appVersionCore" . -}}
 {{- if or (not $core) (semverCompare "<6.4.0" $core) -}}true{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/spacelift-self-hosted/templates/_helpers.tpl
+++ b/spacelift-self-hosted/templates/_helpers.tpl
@@ -139,14 +139,53 @@ Create the name of the service account to use for the drain.
 
 {{/*
 Create the name of the service account to use for the scheduler.
+Falls back to the drain's service account when the scheduler has none of its own
+but the drain does. This is the case on installations whose infrastructure module
+already stopped provisioning a scheduler service account, while the application
+is still old enough to need the standalone scheduler. The drain's permissions are
+a superset of the scheduler's, so it is a safe identity to borrow.
 */}}
 {{- define "spacelift.schedulerServiceAccountName" -}}
 {{- if .Values.scheduler.serviceAccount.create }}
 {{- .Values.scheduler.serviceAccount.name }}
+{{- else if .Values.drain.serviceAccount.create }}
+{{- .Values.drain.serviceAccount.name }}
 {{- else }}
 {{- include "spacelift.serviceAccountName" . }}
 {{- end }}
 {{- end }}
+
+{{/*
+The application version, taken from the tag of .Values.shared.image.
+
+Returns the "X.Y.Z" core of the tag, or an empty string when there is no tag or
+the tag is not a version at all. Released versions are always a plain vX.Y.Z, so
+anything else is a development build, which is newer than every release.
+*/}}
+{{- define "spacelift.appVersionCore" -}}
+{{- $ref := .Values.shared.image | default "" -}}
+{{- $parts := $ref | splitList "/" | last | splitList ":" -}}
+{{- if eq (len $parts) 2 -}}
+{{- $tag := index $parts 1 -}}
+{{- if regexMatch "^v?[0-9]+\\.[0-9]+\\.[0-9]+([-+].*)?$" $tag -}}
+{{- regexFind "[0-9]+\\.[0-9]+\\.[0-9]+" $tag -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Whether the standalone scheduler workload still has to be deployed.
+
+From application v6.4.0 on, the drain always runs the cron scheduler itself, so a
+separate scheduler workload is redundant. Below that it is required, and so is
+the case where the version cannot be read: the scheduler is kept, because losing
+it on an application that does not schedule on its own would silently stop all
+recurring work.
+*/}}
+{{- define "spacelift.deployStandaloneScheduler" -}}
+{{- $core := include "spacelift.appVersionCore" . -}}
+{{- if or (not $core) (semverCompare "<6.4.0" $core) -}}true{{- end -}}
+{{- end -}}
 
 {{/*
 Expand the name of the VCS Gateway.

--- a/spacelift-self-hosted/templates/scheduler-deployment.yaml
+++ b/spacelift-self-hosted/templates/scheduler-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if include "spacelift.deployStandaloneScheduler" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -148,3 +149,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/spacelift-self-hosted/templates/scheduler-pdb.yaml
+++ b/spacelift-self-hosted/templates/scheduler-pdb.yaml
@@ -1,3 +1,4 @@
+{{- if include "spacelift.deployStandaloneScheduler" . }}
 {{- with .Values.scheduler.pdb }}
 {{- if .enabled }}
 {{ include "spacelift.validatePodDisruptionBudget" . }}
@@ -18,5 +19,6 @@ spec:
   selector:
     matchLabels:
       {{- include "spacelift.schedulerSelectorLabels" $ | nindent 6 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/spacelift-self-hosted/templates/scheduler-serviceaccount.yaml
+++ b/spacelift-self-hosted/templates/scheduler-serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if include "spacelift.deployStandaloneScheduler" . }}
 {{- if .Values.scheduler.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
@@ -10,4 +11,5 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.scheduler.serviceAccount.automount }}
+{{- end }}
 {{- end }}

--- a/spacelift-self-hosted/values.schema.json
+++ b/spacelift-self-hosted/values.schema.json
@@ -187,6 +187,14 @@
       "description": "Standalone scheduler component configuration. Only used for applications older than v6.4.0, which is where the drain started running the cron scheduler itself. On v6.4.0 and newer the workload is not deployed and these values are ignored.",
       "additionalProperties": false,
       "properties": {
+        "enabled": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null,
+          "description": "Whether to deploy the standalone scheduler workload. Leave null to decide from the application version read out of shared.image; set true to always deploy it, false to never deploy it. Useful when the image tag does not carry a readable version."
+        },
         "replicaCount": {
           "type": "integer",
           "default": 3,

--- a/spacelift-self-hosted/values.schema.json
+++ b/spacelift-self-hosted/values.schema.json
@@ -184,7 +184,7 @@
     },
     "scheduler": {
       "type": "object",
-      "description": "Scheduler component configuration",
+      "description": "Standalone scheduler component configuration. Only used for applications older than v6.4.0, which is where the drain started running the cron scheduler itself. On v6.4.0 and newer the workload is not deployed and these values are ignored.",
       "additionalProperties": false,
       "properties": {
         "replicaCount": {

--- a/spacelift-self-hosted/values.yaml
+++ b/spacelift-self-hosted/values.yaml
@@ -73,6 +73,10 @@ drain:
   pdb:
     enabled: false
 
+# The standalone scheduler workload is only deployed for applications older than
+# v6.4.0. From v6.4.0 on the drain runs the cron scheduler itself, and everything
+# below is ignored. The version is read from the tag of shared.image; if it cannot
+# be read, the workload is deployed. See templates/_helpers.tpl.
 scheduler:
   replicaCount: 3
   pullPolicy: Always

--- a/spacelift-self-hosted/values.yaml
+++ b/spacelift-self-hosted/values.yaml
@@ -78,6 +78,13 @@ drain:
 # below is ignored. The version is read from the tag of shared.image; if it cannot
 # be read, the workload is deployed. See templates/_helpers.tpl.
 scheduler:
+  # Whether to deploy the standalone scheduler workload:
+  #   null  - decide from the application version in shared.image (default)
+  #   true  - always deploy it
+  #   false - never deploy it
+  # Set it explicitly when the image tag does not carry a readable version, for
+  # example when a registry mirror rewrites tags or the build is not a release.
+  enabled: null
   replicaCount: 3
   pullPolicy: Always
   securityContext:


### PR DESCRIPTION
## What this does

We want remove standalone `scheduler` service from the helm-charts, but it must be backward compatible. The problem is that a customer can run Helm upgrade without specifying the version of Helm charts with spacelift versions < 6.4. This way we should not remove the scheduler for those.

This PR does this instead simple deletion:
- it reads the app version from the tag of `shared.image` and tries it best to parse it;
- and deploys the scheduler only when the app is older than v6.4.0;
- if the version cannot be read from the tag, the chart keeps the workload and says why in `NOTES.txt`.

Aditionally, it introduces new `scheduler.enabled` value to forcefully specify if the standalone `scheduler` service must be ran. If this var is specified (non null), it overrides the automatic behavious from above.

| Value | What happens |
|---|---|
| `null` (default) | the chart decides from the app version in `shared.image` |
| `true` | always deploy the workload |
| `false` | never deploy it |

## What we don't cover

The new major of the Terraform modules stops creating the scheduler service account and its IAM role. If you take that major while still running an app older than v6.4.0, the chart will deploy the scheduler with no service account behind it and `helm upgrade --wait` will fail. That's fine: a major is a breaking change, and its upgrade note already says it needs Self-Hosted v6.4.0 or newer. We don't want a workaround in the chart that makes every new module work with every old app.

## Follow-up work

It's obviously a workaround. We should have some way to pass exact version to Helm charts, not guessing it. Later work can introduce such input parameter. 

We should also think about compatibility matrix feature. For example, we might want to limit the minimum version of application which is supported by the Helm charts.

## Testing

`helm lint --strict` passes. Checked with `helm template` and `helm install --dry-run`:

- deployed for v5.1.0, v6.1.9, v6.3.0, v6.3.1, and for tags that are not versions (`latest`, a digest, no tag at all)
- not deployed for v6.4.0, v6.5.1, v7.0.0, v6.4.0-rc.1
- the tag is read correctly from full registry paths, including a registry with a port
- `scheduler.enabled` wins both ways: forced on at v6.4.0, forced off at v6.3.1, and the schema rejects a value that is not a boolean
- the Deployment, the PDB and the ServiceAccount are all behind the same check, so nothing appears at v6.4.0 even with `scheduler.pdb.enabled=true` and `scheduler.serviceAccount.create=true`
- the scheduler service account resolves the same way as on `main`: its own when the values ask for one, the shared one otherwise
- old `scheduler.*` values still pass validation and still work while the workload is deployed
- all four `NOTES.txt` messages are correct, and at v6.4.0 with no override there is no extra message

## Checklist

- [ ] A chart version is updated (not needed here, `version` in `Chart.yaml` is overridden with `--version` at publish time)
  - [x] No changes on CRDs
  - [ ] CRDs are updated


