### PR TITLE
feat(promex): support extra pod labels

### DIFF
--- a/spacelift-promex/Chart.yaml
+++ b/spacelift-promex/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: spacelift-promex
 description: A Helm chart for deploying the Spacelift Prometheus exporter.
 type: application
-version: 0.0.4
+version: 0.0.5
 appVersion: "v0.7.0"

--- a/spacelift-promex/templates/deployment.yaml
+++ b/spacelift-promex/templates/deployment.yaml
@@ -20,6 +20,9 @@ spec:
     metadata:
       labels:
         {{- include "spacelift-promex.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/spacelift-promex/values.yaml
+++ b/spacelift-promex/values.yaml
@@ -21,6 +21,10 @@ annotations:
 # podAnnotations:
 #   app.spacelift.io/example: spacelift-promx
 
+# Labels to add to the pod
+# podLabels:
+#   app.spacelift.io/example: spacelift-promx
+
 # Priority class name for the pod
 priorityClassName: ""
 


### PR DESCRIPTION
## Summary
- Add a `podLabels` values field to `spacelift-promex`, following the existing `podAnnotations` pattern, so extra labels can be set on the Deployment's pod template.
- Bump chart version to `0.0.5`.

## Test plan
- [x] `helm lint spacelift-promex/`
- [x] `helm template` with `--set podLabels.foo=bar` and confirmed the label renders on `spec.template.metadata.labels`
