### PR TITLE
feat(workerpool-controller): bump to v0.0.42

### DIFF
--- a/spacelift-workerpool-controller/Chart.yaml
+++ b/spacelift-workerpool-controller/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: spacelift-workerpool-controller
 description: A Helm chart for deploying spacelift workerpool controller
 type: application
-version: v0.20.0  # VERSION
-appVersion: "v0.0.41"
+version: v0.21.0  # VERSION
+appVersion: "v0.0.42"
 
 dependencies:
   - name: crds
-    version: v0.20.0  # VERSION
+    version: v0.21.0  # VERSION
     condition: crds.install
   - name: spacelift-promex
     version: 0.73.0

--- a/spacelift-workerpool-controller/Makefile
+++ b/spacelift-workerpool-controller/Makefile
@@ -2,13 +2,13 @@ SHELL := /bin/bash
 
 CRDS_PATH ?= config/crd/bases
 CRDS_OUT_DIR ?= charts/crds/templates
-CHART_VERSION ?= v0.20.0
+CHART_VERSION ?= v0.21.0
 
 .PHONY: codegen-helm
 codegen-helm: codegen-helm-crds codegen-helm-update-versions
 
 .PHONY: codegen-helm-crds
-codegen-helm-crds: 
+codegen-helm-crds:
 	@echo "Generate helm CRDs..." >&2
 	@test -d $(CRDS_PATH) || (echo "CRDS_PATH not found: $(CRDS_PATH)" >&2; exit 1)
 	@rm -rf $(CRDS_OUT_DIR)
@@ -34,7 +34,7 @@ define generate_crd
 endef
 
 .PHONY: codegen-helm-update-versions
-codegen-helm-update-versions: 
+codegen-helm-update-versions:
 	@echo "Updating Chart.yaml files..." >&2
 	@sed -i.bak 's/version: .*  # VERSION/version: $(CHART_VERSION)  # VERSION/' Chart.yaml
 	@rm -f Chart.yaml.bak

--- a/spacelift-workerpool-controller/charts/crds/Chart.yaml
+++ b/spacelift-workerpool-controller/charts/crds/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: crds
-version: v0.20.0  # VERSION
+version: v0.21.0  # VERSION

--- a/spacelift-workerpool-controller/charts/crds/templates/workerpool-crd.yaml
+++ b/spacelift-workerpool-controller/charts/crds/templates/workerpool-crd.yaml
@@ -209,7 +209,9 @@ spec:
                                     description: Selects a key of a ConfigMap.
                                     properties:
                                       key:
-                                        description: The key to select.
+                                        description: |-
+                                          The key to select from the ConfigMap's Data field.
+                                          Keys in the BinaryData field are not currently propagated to container env vars.
                                         type: string
                                       name:
                                         default: ""
@@ -480,6 +482,11 @@ spec:
                                         Number must be in the range 1 to 65535.
                                         Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        Protocol selects the wire protocol for the probe connection.
+                                        Nil defaults to HTTP/1.1.
+                                      type: string
                                     scheme:
                                       description: |-
                                         Scheme to use for connecting to the host.
@@ -593,6 +600,11 @@ spec:
                                         Number must be in the range 1 to 65535.
                                         Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        Protocol selects the wire protocol for the probe connection.
+                                        Nil defaults to HTTP/1.1.
+                                      type: string
                                     scheme:
                                       description: |-
                                         Scheme to use for connecting to the host.
@@ -675,6 +687,13 @@ spec:
                             grpc:
                               description: GRPC specifies a GRPC HealthCheckRequest.
                               properties:
+                                mode:
+                                  description: |-
+                                    mode specifies the connection mode for the gRPC health probe.
+                                    Set to "TLS" to use TLS without certificate verification.
+                                    Set to "Plaintext" to use a plaintext (insecure) connection explicitly.
+                                    If not specified, the probe uses a plaintext (insecure) connection.
+                                  type: string
                                 port:
                                   description: Port number of the gRPC service. Number
                                     must be in the range 1 to 65535.
@@ -733,6 +752,11 @@ spec:
                                     Number must be in the range 1 to 65535.
                                     Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
+                                protocol:
+                                  description: |-
+                                    Protocol selects the wire protocol for the probe connection.
+                                    Nil defaults to HTTP/1.1.
+                                  type: string
                                 scheme:
                                   description: |-
                                     Scheme to use for connecting to the host.
@@ -890,6 +914,13 @@ spec:
                             grpc:
                               description: GRPC specifies a GRPC HealthCheckRequest.
                               properties:
+                                mode:
+                                  description: |-
+                                    mode specifies the connection mode for the gRPC health probe.
+                                    Set to "TLS" to use TLS without certificate verification.
+                                    Set to "Plaintext" to use a plaintext (insecure) connection explicitly.
+                                    If not specified, the probe uses a plaintext (insecure) connection.
+                                  type: string
                                 port:
                                   description: Port number of the gRPC service. Number
                                     must be in the range 1 to 65535.
@@ -948,6 +979,11 @@ spec:
                                     Number must be in the range 1 to 65535.
                                     Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
+                                protocol:
+                                  description: |-
+                                    Protocol selects the wire protocol for the probe connection.
+                                    Nil defaults to HTTP/1.1.
+                                  type: string
                                 scheme:
                                   description: |-
                                     Scheme to use for connecting to the host.
@@ -1403,6 +1439,13 @@ spec:
                             grpc:
                               description: GRPC specifies a GRPC HealthCheckRequest.
                               properties:
+                                mode:
+                                  description: |-
+                                    mode specifies the connection mode for the gRPC health probe.
+                                    Set to "TLS" to use TLS without certificate verification.
+                                    Set to "Plaintext" to use a plaintext (insecure) connection explicitly.
+                                    If not specified, the probe uses a plaintext (insecure) connection.
+                                  type: string
                                 port:
                                   description: Port number of the gRPC service. Number
                                     must be in the range 1 to 65535.
@@ -1461,6 +1504,11 @@ spec:
                                     Number must be in the range 1 to 65535.
                                     Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
+                                protocol:
+                                  description: |-
+                                    Protocol selects the wire protocol for the probe connection.
+                                    Nil defaults to HTTP/1.1.
+                                  type: string
                                 scheme:
                                   description: |-
                                     Scheme to use for connecting to the host.
@@ -1601,10 +1649,21 @@ spec:
                             description: VolumeMount describes a mounting of a Volume
                               within a container.
                             properties:
-                              mountPath:
+                              bindMountOptions:
                                 description: |-
-                                  Path within the container at which the volume should be mounted.  Must
-                                  not contain ':'.
+                                  bindMountOptions is the list of additional bind mount options to apply when
+                                  mounting this volume into the container. Allowed values are noexec,
+                                  nodev, and nosuid. These are Linux mount options and have no effect on
+                                  Windows nodes.
+                                  This field is not supported with image volumes.
+                                  This is an alpha field and requires enabling the VolumeBindMountOptions feature gate.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.
                                 type: string
                               mountPropagation:
                                 description: |-
@@ -2823,6 +2882,13 @@ spec:
                               mode, like fsGroup, and the result can be other mode bits set.
                             format: int32
                             type: integer
+                          defaultUser:
+                            description: |-
+                              defaultUser is Optional: The owner UID of the created files by default.
+                              The defaultUser field is only used as a fallback when the item-level user field is unset.
+                              (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                            format: int64
+                            type: integer
                           items:
                             description: |-
                               items if unspecified, each key-value pair in the Data field of the referenced
@@ -2855,6 +2921,13 @@ spec:
                                     May not contain the path element '..'.
                                     May not start with the string '..'.
                                   type: string
+                                user:
+                                  description: |-
+                                    user is Optional: The owner UID of the created file.
+                                    If specified, the item-level user field takes precedence over defaultUser.
+                                    (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                  format: int64
+                                  type: integer
                               required:
                               - key
                               - path
@@ -2942,6 +3015,13 @@ spec:
                               mode, like fsGroup, and the result can be other mode bits set.
                             format: int32
                             type: integer
+                          defaultUser:
+                            description: |-
+                              defaultUser is Optional: The owner UID of the created files by default.
+                              The defaultUser field is only used as a fallback when the item-level user field is unset.
+                              (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                            format: int64
+                            type: integer
                           items:
                             description: Items is a list of downward API volume file
                             items:
@@ -3006,6 +3086,13 @@ spec:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                user:
+                                  description: |-
+                                    user is Optional: The owner UID of the created file.
+                                    If specified, the item-level user field takes precedence over defaultUser.
+                                    (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                  format: int64
+                                  type: integer
                               required:
                               - path
                               type: object
@@ -3024,6 +3111,18 @@ spec:
                               Must be an empty string (default) or Memory.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                             type: string
+                          mode:
+                            description: |-
+                              mode specifies the permission bits for the emptyDir directory, in numeric
+                              notation (e.g., 0755, 01777). Must be a value between 0000 and 01777.
+                              If not specified, defaults to 0777.
+                              This might be in conflict with other options that affect the file
+                              mode, like fsGroup. If fsGroup is specified, the fsGroup permissions
+                              will override the mode specified here.
+                              This field has no effect on Windows.
+                              This field is alpha and requires EmptyDirVolumeMode featuregate to be enabled.
+                            format: int32
+                            type: integer
                           sizeLimit:
                             anyOf:
                             - type: integer
@@ -3117,8 +3216,8 @@ spec:
                                       * An existing PVC (PersistentVolumeClaim)
                                       If the provisioner or an external controller can support the specified data source,
                                       it will create a new volume based on the contents of the specified data source.
-                                      When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                      and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                      dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be
+                                      copied to dataSource when dataSourceRef.namespace is not specified.
                                       If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                     properties:
                                       apiGroup:
@@ -3163,7 +3262,6 @@ spec:
                                         specified.
                                       * While dataSource only allows local objects, dataSourceRef allows objects
                                         in any namespaces.
-                                      (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
                                       (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                     properties:
                                       apiGroup:
@@ -3730,6 +3828,13 @@ spec:
                               mode, like fsGroup, and the result can be other mode bits set.
                             format: int32
                             type: integer
+                          defaultUser:
+                            description: |-
+                              defaultUser is Optional: The owner UID of the created files by default.
+                              The defaultUser field is only used as a fallback when the item-level user field is unset.
+                              (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                            format: int64
+                            type: integer
                           sources:
                             description: |-
                               sources is the list of volume projections. Each entry in this list
@@ -3829,6 +3934,13 @@ spec:
                                         Mutually-exclusive with name.  The contents of all selected
                                         ClusterTrustBundles will be unified and deduplicated.
                                       type: string
+                                    user:
+                                      description: |-
+                                        user is Optional: The owner UID of the created file.
+                                        If specified, the item-level user field takes precedence over defaultUser.
+                                        (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                      format: int64
+                                      type: integer
                                   required:
                                   - path
                                   type: object
@@ -3869,6 +3981,13 @@ spec:
                                               May not contain the path element '..'.
                                               May not start with the string '..'.
                                             type: string
+                                          user:
+                                            description: |-
+                                              user is Optional: The owner UID of the created file.
+                                              If specified, the item-level user field takes precedence over defaultUser.
+                                              (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                            format: int64
+                                            type: integer
                                         required:
                                         - key
                                         - path
@@ -3964,6 +4083,13 @@ spec:
                                             - resource
                                             type: object
                                             x-kubernetes-map-type: atomic
+                                          user:
+                                            description: |-
+                                              user is Optional: The owner UID of the created file.
+                                              If specified, the item-level user field takes precedence over defaultUser.
+                                              (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                            format: int64
+                                            type: integer
                                         required:
                                         - path
                                         type: object
@@ -4071,6 +4197,13 @@ spec:
                                       description: Kubelet's generated CSRs will be
                                         addressed to this signer.
                                       type: string
+                                    user:
+                                      description: |-
+                                        user is Optional: The owner UID of the created file.
+                                        If specified, the item-level user field takes precedence over defaultUser.
+                                        (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                      format: int64
+                                      type: integer
                                     userAnnotations:
                                       additionalProperties:
                                         type: string
@@ -4130,6 +4263,13 @@ spec:
                                               May not contain the path element '..'.
                                               May not start with the string '..'.
                                             type: string
+                                          user:
+                                            description: |-
+                                              user is Optional: The owner UID of the created file.
+                                              If specified, the item-level user field takes precedence over defaultUser.
+                                              (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                            format: int64
+                                            type: integer
                                         required:
                                         - key
                                         - path
@@ -4177,6 +4317,13 @@ spec:
                                         path is the path relative to the mount point of the file to project the
                                         token into.
                                       type: string
+                                    user:
+                                      description: |-
+                                        user is Optional: The owner UID of the created file.
+                                        If specified, the item-level user field takes precedence over defaultUser.
+                                        (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                      format: int64
+                                      type: integer
                                   required:
                                   - path
                                   type: object
@@ -4383,6 +4530,13 @@ spec:
                               mode, like fsGroup, and the result can be other mode bits set.
                             format: int32
                             type: integer
+                          defaultUser:
+                            description: |-
+                              defaultUser is Optional: The owner UID of the created files by default.
+                              The defaultUser field is only used as a fallback when the item-level user field is unset.
+                              (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                            format: int64
+                            type: integer
                           items:
                             description: |-
                               items If unspecified, each key-value pair in the Data field of the referenced
@@ -4415,6 +4569,13 @@ spec:
                                     May not contain the path element '..'.
                                     May not start with the string '..'.
                                   type: string
+                                user:
+                                  description: |-
+                                    user is Optional: The owner UID of the created file.
+                                    If specified, the item-level user field takes precedence over defaultUser.
+                                    (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                  format: int64
+                                  type: integer
                               required:
                               - key
                               - path
@@ -4582,7 +4743,9 @@ spec:
                                     description: Selects a key of a ConfigMap.
                                     properties:
                                       key:
-                                        description: The key to select.
+                                        description: |-
+                                          The key to select from the ConfigMap's Data field.
+                                          Keys in the BinaryData field are not currently propagated to container env vars.
                                         type: string
                                       name:
                                         default: ""
@@ -4853,6 +5016,11 @@ spec:
                                         Number must be in the range 1 to 65535.
                                         Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        Protocol selects the wire protocol for the probe connection.
+                                        Nil defaults to HTTP/1.1.
+                                      type: string
                                     scheme:
                                       description: |-
                                         Scheme to use for connecting to the host.
@@ -4966,6 +5134,11 @@ spec:
                                         Number must be in the range 1 to 65535.
                                         Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        Protocol selects the wire protocol for the probe connection.
+                                        Nil defaults to HTTP/1.1.
+                                      type: string
                                     scheme:
                                       description: |-
                                         Scheme to use for connecting to the host.
@@ -5048,6 +5221,13 @@ spec:
                             grpc:
                               description: GRPC specifies a GRPC HealthCheckRequest.
                               properties:
+                                mode:
+                                  description: |-
+                                    mode specifies the connection mode for the gRPC health probe.
+                                    Set to "TLS" to use TLS without certificate verification.
+                                    Set to "Plaintext" to use a plaintext (insecure) connection explicitly.
+                                    If not specified, the probe uses a plaintext (insecure) connection.
+                                  type: string
                                 port:
                                   description: Port number of the gRPC service. Number
                                     must be in the range 1 to 65535.
@@ -5106,6 +5286,11 @@ spec:
                                     Number must be in the range 1 to 65535.
                                     Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
+                                protocol:
+                                  description: |-
+                                    Protocol selects the wire protocol for the probe connection.
+                                    Nil defaults to HTTP/1.1.
+                                  type: string
                                 scheme:
                                   description: |-
                                     Scheme to use for connecting to the host.
@@ -5263,6 +5448,13 @@ spec:
                             grpc:
                               description: GRPC specifies a GRPC HealthCheckRequest.
                               properties:
+                                mode:
+                                  description: |-
+                                    mode specifies the connection mode for the gRPC health probe.
+                                    Set to "TLS" to use TLS without certificate verification.
+                                    Set to "Plaintext" to use a plaintext (insecure) connection explicitly.
+                                    If not specified, the probe uses a plaintext (insecure) connection.
+                                  type: string
                                 port:
                                   description: Port number of the gRPC service. Number
                                     must be in the range 1 to 65535.
@@ -5321,6 +5513,11 @@ spec:
                                     Number must be in the range 1 to 65535.
                                     Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
+                                protocol:
+                                  description: |-
+                                    Protocol selects the wire protocol for the probe connection.
+                                    Nil defaults to HTTP/1.1.
+                                  type: string
                                 scheme:
                                   description: |-
                                     Scheme to use for connecting to the host.
@@ -5776,6 +5973,13 @@ spec:
                             grpc:
                               description: GRPC specifies a GRPC HealthCheckRequest.
                               properties:
+                                mode:
+                                  description: |-
+                                    mode specifies the connection mode for the gRPC health probe.
+                                    Set to "TLS" to use TLS without certificate verification.
+                                    Set to "Plaintext" to use a plaintext (insecure) connection explicitly.
+                                    If not specified, the probe uses a plaintext (insecure) connection.
+                                  type: string
                                 port:
                                   description: Port number of the gRPC service. Number
                                     must be in the range 1 to 65535.
@@ -5834,6 +6038,11 @@ spec:
                                     Number must be in the range 1 to 65535.
                                     Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
+                                protocol:
+                                  description: |-
+                                    Protocol selects the wire protocol for the probe connection.
+                                    Nil defaults to HTTP/1.1.
+                                  type: string
                                 scheme:
                                   description: |-
                                     Scheme to use for connecting to the host.
@@ -5974,10 +6183,21 @@ spec:
                             description: VolumeMount describes a mounting of a Volume
                               within a container.
                             properties:
-                              mountPath:
+                              bindMountOptions:
                                 description: |-
-                                  Path within the container at which the volume should be mounted.  Must
-                                  not contain ':'.
+                                  bindMountOptions is the list of additional bind mount options to apply when
+                                  mounting this volume into the container. Allowed values are noexec,
+                                  nodev, and nosuid. These are Linux mount options and have no effect on
+                                  Windows nodes.
+                                  This field is not supported with image volumes.
+                                  This is an alpha field and requires enabling the VolumeBindMountOptions feature gate.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.
                                 type: string
                               mountPropagation:
                                 description: |-
@@ -6154,7 +6374,9 @@ spec:
                                   description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
+                                      description: |-
+                                        The key to select from the ConfigMap's Data field.
+                                        Keys in the BinaryData field are not currently propagated to container env vars.
                                       type: string
                                     name:
                                       default: ""
@@ -6418,6 +6640,11 @@ spec:
                                       Number must be in the range 1 to 65535.
                                       Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
+                                  protocol:
+                                    description: |-
+                                      Protocol selects the wire protocol for the probe connection.
+                                      Nil defaults to HTTP/1.1.
+                                    type: string
                                   scheme:
                                     description: |-
                                       Scheme to use for connecting to the host.
@@ -6531,6 +6758,11 @@ spec:
                                       Number must be in the range 1 to 65535.
                                       Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
+                                  protocol:
+                                    description: |-
+                                      Protocol selects the wire protocol for the probe connection.
+                                      Nil defaults to HTTP/1.1.
+                                    type: string
                                   scheme:
                                     description: |-
                                       Scheme to use for connecting to the host.
@@ -6848,10 +7080,21 @@ spec:
                           description: VolumeMount describes a mounting of a Volume
                             within a container.
                           properties:
-                            mountPath:
+                            bindMountOptions:
                               description: |-
-                                Path within the container at which the volume should be mounted.  Must
-                                not contain ':'.
+                                bindMountOptions is the list of additional bind mount options to apply when
+                                mounting this volume into the container. Allowed values are noexec,
+                                nodev, and nosuid. These are Linux mount options and have no effect on
+                                Windows nodes.
+                                This field is not supported with image volumes.
+                                This is an alpha field and requires enabling the VolumeBindMountOptions feature gate.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            mountPath:
+                              description: Path within the container at which the
+                                volume should be mounted.
                               type: string
                             mountPropagation:
                               description: |-
@@ -6988,7 +7231,9 @@ spec:
                                   description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
+                                      description: |-
+                                        The key to select from the ConfigMap's Data field.
+                                        Keys in the BinaryData field are not currently propagated to container env vars.
                                       type: string
                                     name:
                                       default: ""
@@ -7252,6 +7497,11 @@ spec:
                                       Number must be in the range 1 to 65535.
                                       Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
+                                  protocol:
+                                    description: |-
+                                      Protocol selects the wire protocol for the probe connection.
+                                      Nil defaults to HTTP/1.1.
+                                    type: string
                                   scheme:
                                     description: |-
                                       Scheme to use for connecting to the host.
@@ -7365,6 +7615,11 @@ spec:
                                       Number must be in the range 1 to 65535.
                                       Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
+                                  protocol:
+                                    description: |-
+                                      Protocol selects the wire protocol for the probe connection.
+                                      Nil defaults to HTTP/1.1.
+                                    type: string
                                   scheme:
                                     description: |-
                                       Scheme to use for connecting to the host.
@@ -7682,10 +7937,21 @@ spec:
                           description: VolumeMount describes a mounting of a Volume
                             within a container.
                           properties:
-                            mountPath:
+                            bindMountOptions:
                               description: |-
-                                Path within the container at which the volume should be mounted.  Must
-                                not contain ':'.
+                                bindMountOptions is the list of additional bind mount options to apply when
+                                mounting this volume into the container. Allowed values are noexec,
+                                nodev, and nosuid. These are Linux mount options and have no effect on
+                                Windows nodes.
+                                This field is not supported with image volumes.
+                                This is an alpha field and requires enabling the VolumeBindMountOptions feature gate.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            mountPath:
+                              description: Path within the container at which the
+                                volume should be mounted.
                               type: string
                             mountPropagation:
                               description: |-
@@ -7882,11 +8148,8 @@ spec:
                           Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
                           whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
                           CSIDriver instance. Other volumes are always re-labelled recursively.
-                          "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
 
-                          If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
-                          If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
-                          and "Recursive" for all other volumes.
+                          If not specified, "MountOption" is used.
 
                           This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
 
@@ -8478,6 +8741,13 @@ spec:
                                 mode, like fsGroup, and the result can be other mode bits set.
                               format: int32
                               type: integer
+                            defaultUser:
+                              description: |-
+                                defaultUser is Optional: The owner UID of the created files by default.
+                                The defaultUser field is only used as a fallback when the item-level user field is unset.
+                                (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                              format: int64
+                              type: integer
                             items:
                               description: |-
                                 items if unspecified, each key-value pair in the Data field of the referenced
@@ -8511,6 +8781,13 @@ spec:
                                       May not contain the path element '..'.
                                       May not start with the string '..'.
                                     type: string
+                                  user:
+                                    description: |-
+                                      user is Optional: The owner UID of the created file.
+                                      If specified, the item-level user field takes precedence over defaultUser.
+                                      (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                    format: int64
+                                    type: integer
                                 required:
                                 - key
                                 - path
@@ -8598,6 +8875,13 @@ spec:
                                 mode, like fsGroup, and the result can be other mode bits set.
                               format: int32
                               type: integer
+                            defaultUser:
+                              description: |-
+                                defaultUser is Optional: The owner UID of the created files by default.
+                                The defaultUser field is only used as a fallback when the item-level user field is unset.
+                                (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                              format: int64
+                              type: integer
                             items:
                               description: Items is a list of downward API volume
                                 file
@@ -8663,6 +8947,13 @@ spec:
                                     - resource
                                     type: object
                                     x-kubernetes-map-type: atomic
+                                  user:
+                                    description: |-
+                                      user is Optional: The owner UID of the created file.
+                                      If specified, the item-level user field takes precedence over defaultUser.
+                                      (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                    format: int64
+                                    type: integer
                                 required:
                                 - path
                                 type: object
@@ -8681,6 +8972,18 @@ spec:
                                 Must be an empty string (default) or Memory.
                                 More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                               type: string
+                            mode:
+                              description: |-
+                                mode specifies the permission bits for the emptyDir directory, in numeric
+                                notation (e.g., 0755, 01777). Must be a value between 0000 and 01777.
+                                If not specified, defaults to 0777.
+                                This might be in conflict with other options that affect the file
+                                mode, like fsGroup. If fsGroup is specified, the fsGroup permissions
+                                will override the mode specified here.
+                                This field has no effect on Windows.
+                                This field is alpha and requires EmptyDirVolumeMode featuregate to be enabled.
+                              format: int32
+                              type: integer
                             sizeLimit:
                               anyOf:
                               - type: integer
@@ -8774,8 +9077,8 @@ spec:
                                         * An existing PVC (PersistentVolumeClaim)
                                         If the provisioner or an external controller can support the specified data source,
                                         it will create a new volume based on the contents of the specified data source.
-                                        When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                        and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                        dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be
+                                        copied to dataSource when dataSourceRef.namespace is not specified.
                                         If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                       properties:
                                         apiGroup:
@@ -8820,7 +9123,6 @@ spec:
                                           specified.
                                         * While dataSource only allows local objects, dataSourceRef allows objects
                                           in any namespaces.
-                                        (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
                                         (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                       properties:
                                         apiGroup:
@@ -9388,6 +9690,13 @@ spec:
                                 mode, like fsGroup, and the result can be other mode bits set.
                               format: int32
                               type: integer
+                            defaultUser:
+                              description: |-
+                                defaultUser is Optional: The owner UID of the created files by default.
+                                The defaultUser field is only used as a fallback when the item-level user field is unset.
+                                (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                              format: int64
+                              type: integer
                             sources:
                               description: |-
                                 sources is the list of volume projections. Each entry in this list
@@ -9487,6 +9796,13 @@ spec:
                                           Mutually-exclusive with name.  The contents of all selected
                                           ClusterTrustBundles will be unified and deduplicated.
                                         type: string
+                                      user:
+                                        description: |-
+                                          user is Optional: The owner UID of the created file.
+                                          If specified, the item-level user field takes precedence over defaultUser.
+                                          (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                        format: int64
+                                        type: integer
                                     required:
                                     - path
                                     type: object
@@ -9527,6 +9843,13 @@ spec:
                                                 May not contain the path element '..'.
                                                 May not start with the string '..'.
                                               type: string
+                                            user:
+                                              description: |-
+                                                user is Optional: The owner UID of the created file.
+                                                If specified, the item-level user field takes precedence over defaultUser.
+                                                (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                              format: int64
+                                              type: integer
                                           required:
                                           - key
                                           - path
@@ -9623,6 +9946,13 @@ spec:
                                               - resource
                                               type: object
                                               x-kubernetes-map-type: atomic
+                                            user:
+                                              description: |-
+                                                user is Optional: The owner UID of the created file.
+                                                If specified, the item-level user field takes precedence over defaultUser.
+                                                (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                              format: int64
+                                              type: integer
                                           required:
                                           - path
                                           type: object
@@ -9730,6 +10060,13 @@ spec:
                                         description: Kubelet's generated CSRs will
                                           be addressed to this signer.
                                         type: string
+                                      user:
+                                        description: |-
+                                          user is Optional: The owner UID of the created file.
+                                          If specified, the item-level user field takes precedence over defaultUser.
+                                          (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                        format: int64
+                                        type: integer
                                       userAnnotations:
                                         additionalProperties:
                                           type: string
@@ -9789,6 +10126,13 @@ spec:
                                                 May not contain the path element '..'.
                                                 May not start with the string '..'.
                                               type: string
+                                            user:
+                                              description: |-
+                                                user is Optional: The owner UID of the created file.
+                                                If specified, the item-level user field takes precedence over defaultUser.
+                                                (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                              format: int64
+                                              type: integer
                                           required:
                                           - key
                                           - path
@@ -9836,6 +10180,13 @@ spec:
                                           path is the path relative to the mount point of the file to project the
                                           token into.
                                         type: string
+                                      user:
+                                        description: |-
+                                          user is Optional: The owner UID of the created file.
+                                          If specified, the item-level user field takes precedence over defaultUser.
+                                          (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                        format: int64
+                                        type: integer
                                     required:
                                     - path
                                     type: object
@@ -10042,6 +10393,13 @@ spec:
                                 mode, like fsGroup, and the result can be other mode bits set.
                               format: int32
                               type: integer
+                            defaultUser:
+                              description: |-
+                                defaultUser is Optional: The owner UID of the created files by default.
+                                The defaultUser field is only used as a fallback when the item-level user field is unset.
+                                (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                              format: int64
+                              type: integer
                             items:
                               description: |-
                                 items If unspecified, each key-value pair in the Data field of the referenced
@@ -10075,6 +10433,13 @@ spec:
                                       May not contain the path element '..'.
                                       May not start with the string '..'.
                                     type: string
+                                  user:
+                                    description: |-
+                                      user is Optional: The owner UID of the created file.
+                                      If specified, the item-level user field takes precedence over defaultUser.
+                                      (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                    format: int64
+                                    type: integer
                                 required:
                                 - key
                                 - path
@@ -10206,7 +10571,9 @@ spec:
                                   description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
+                                      description: |-
+                                        The key to select from the ConfigMap's Data field.
+                                        Keys in the BinaryData field are not currently propagated to container env vars.
                                       type: string
                                     name:
                                       default: ""
@@ -10470,6 +10837,11 @@ spec:
                                       Number must be in the range 1 to 65535.
                                       Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
+                                  protocol:
+                                    description: |-
+                                      Protocol selects the wire protocol for the probe connection.
+                                      Nil defaults to HTTP/1.1.
+                                    type: string
                                   scheme:
                                     description: |-
                                       Scheme to use for connecting to the host.
@@ -10583,6 +10955,11 @@ spec:
                                       Number must be in the range 1 to 65535.
                                       Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
+                                  protocol:
+                                    description: |-
+                                      Protocol selects the wire protocol for the probe connection.
+                                      Nil defaults to HTTP/1.1.
+                                    type: string
                                   scheme:
                                     description: |-
                                       Scheme to use for connecting to the host.
@@ -10900,10 +11277,21 @@ spec:
                           description: VolumeMount describes a mounting of a Volume
                             within a container.
                           properties:
-                            mountPath:
+                            bindMountOptions:
                               description: |-
-                                Path within the container at which the volume should be mounted.  Must
-                                not contain ':'.
+                                bindMountOptions is the list of additional bind mount options to apply when
+                                mounting this volume into the container. Allowed values are noexec,
+                                nodev, and nosuid. These are Linux mount options and have no effect on
+                                Windows nodes.
+                                This field is not supported with image volumes.
+                                This is an alpha field and requires enabling the VolumeBindMountOptions feature gate.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            mountPath:
+                              description: Path within the container at which the
+                                volume should be mounted.
                               type: string
                             mountPropagation:
                               description: |-
@@ -11178,6 +11566,13 @@ spec:
                               mode, like fsGroup, and the result can be other mode bits set.
                             format: int32
                             type: integer
+                          defaultUser:
+                            description: |-
+                              defaultUser is Optional: The owner UID of the created files by default.
+                              The defaultUser field is only used as a fallback when the item-level user field is unset.
+                              (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                            format: int64
+                            type: integer
                           items:
                             description: |-
                               items if unspecified, each key-value pair in the Data field of the referenced
@@ -11210,6 +11605,13 @@ spec:
                                     May not contain the path element '..'.
                                     May not start with the string '..'.
                                   type: string
+                                user:
+                                  description: |-
+                                    user is Optional: The owner UID of the created file.
+                                    If specified, the item-level user field takes precedence over defaultUser.
+                                    (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                  format: int64
+                                  type: integer
                               required:
                               - key
                               - path
@@ -11297,6 +11699,13 @@ spec:
                               mode, like fsGroup, and the result can be other mode bits set.
                             format: int32
                             type: integer
+                          defaultUser:
+                            description: |-
+                              defaultUser is Optional: The owner UID of the created files by default.
+                              The defaultUser field is only used as a fallback when the item-level user field is unset.
+                              (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                            format: int64
+                            type: integer
                           items:
                             description: Items is a list of downward API volume file
                             items:
@@ -11361,6 +11770,13 @@ spec:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                user:
+                                  description: |-
+                                    user is Optional: The owner UID of the created file.
+                                    If specified, the item-level user field takes precedence over defaultUser.
+                                    (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                  format: int64
+                                  type: integer
                               required:
                               - path
                               type: object
@@ -11379,6 +11795,18 @@ spec:
                               Must be an empty string (default) or Memory.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                             type: string
+                          mode:
+                            description: |-
+                              mode specifies the permission bits for the emptyDir directory, in numeric
+                              notation (e.g., 0755, 01777). Must be a value between 0000 and 01777.
+                              If not specified, defaults to 0777.
+                              This might be in conflict with other options that affect the file
+                              mode, like fsGroup. If fsGroup is specified, the fsGroup permissions
+                              will override the mode specified here.
+                              This field has no effect on Windows.
+                              This field is alpha and requires EmptyDirVolumeMode featuregate to be enabled.
+                            format: int32
+                            type: integer
                           sizeLimit:
                             anyOf:
                             - type: integer
@@ -11472,8 +11900,8 @@ spec:
                                       * An existing PVC (PersistentVolumeClaim)
                                       If the provisioner or an external controller can support the specified data source,
                                       it will create a new volume based on the contents of the specified data source.
-                                      When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                      and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                      dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be
+                                      copied to dataSource when dataSourceRef.namespace is not specified.
                                       If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                     properties:
                                       apiGroup:
@@ -11518,7 +11946,6 @@ spec:
                                         specified.
                                       * While dataSource only allows local objects, dataSourceRef allows objects
                                         in any namespaces.
-                                      (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
                                       (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                     properties:
                                       apiGroup:
@@ -12085,6 +12512,13 @@ spec:
                               mode, like fsGroup, and the result can be other mode bits set.
                             format: int32
                             type: integer
+                          defaultUser:
+                            description: |-
+                              defaultUser is Optional: The owner UID of the created files by default.
+                              The defaultUser field is only used as a fallback when the item-level user field is unset.
+                              (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                            format: int64
+                            type: integer
                           sources:
                             description: |-
                               sources is the list of volume projections. Each entry in this list
@@ -12184,6 +12618,13 @@ spec:
                                         Mutually-exclusive with name.  The contents of all selected
                                         ClusterTrustBundles will be unified and deduplicated.
                                       type: string
+                                    user:
+                                      description: |-
+                                        user is Optional: The owner UID of the created file.
+                                        If specified, the item-level user field takes precedence over defaultUser.
+                                        (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                      format: int64
+                                      type: integer
                                   required:
                                   - path
                                   type: object
@@ -12224,6 +12665,13 @@ spec:
                                               May not contain the path element '..'.
                                               May not start with the string '..'.
                                             type: string
+                                          user:
+                                            description: |-
+                                              user is Optional: The owner UID of the created file.
+                                              If specified, the item-level user field takes precedence over defaultUser.
+                                              (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                            format: int64
+                                            type: integer
                                         required:
                                         - key
                                         - path
@@ -12319,6 +12767,13 @@ spec:
                                             - resource
                                             type: object
                                             x-kubernetes-map-type: atomic
+                                          user:
+                                            description: |-
+                                              user is Optional: The owner UID of the created file.
+                                              If specified, the item-level user field takes precedence over defaultUser.
+                                              (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                            format: int64
+                                            type: integer
                                         required:
                                         - path
                                         type: object
@@ -12426,6 +12881,13 @@ spec:
                                       description: Kubelet's generated CSRs will be
                                         addressed to this signer.
                                       type: string
+                                    user:
+                                      description: |-
+                                        user is Optional: The owner UID of the created file.
+                                        If specified, the item-level user field takes precedence over defaultUser.
+                                        (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                      format: int64
+                                      type: integer
                                     userAnnotations:
                                       additionalProperties:
                                         type: string
@@ -12485,6 +12947,13 @@ spec:
                                               May not contain the path element '..'.
                                               May not start with the string '..'.
                                             type: string
+                                          user:
+                                            description: |-
+                                              user is Optional: The owner UID of the created file.
+                                              If specified, the item-level user field takes precedence over defaultUser.
+                                              (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                            format: int64
+                                            type: integer
                                         required:
                                         - key
                                         - path
@@ -12532,6 +13001,13 @@ spec:
                                         path is the path relative to the mount point of the file to project the
                                         token into.
                                       type: string
+                                    user:
+                                      description: |-
+                                        user is Optional: The owner UID of the created file.
+                                        If specified, the item-level user field takes precedence over defaultUser.
+                                        (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                      format: int64
+                                      type: integer
                                   required:
                                   - path
                                   type: object
@@ -12738,6 +13214,13 @@ spec:
                               mode, like fsGroup, and the result can be other mode bits set.
                             format: int32
                             type: integer
+                          defaultUser:
+                            description: |-
+                              defaultUser is Optional: The owner UID of the created files by default.
+                              The defaultUser field is only used as a fallback when the item-level user field is unset.
+                              (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                            format: int64
+                            type: integer
                           items:
                             description: |-
                               items If unspecified, each key-value pair in the Data field of the referenced
@@ -12770,6 +13253,13 @@ spec:
                                     May not contain the path element '..'.
                                     May not start with the string '..'.
                                   type: string
+                                user:
+                                  description: |-
+                                    user is Optional: The owner UID of the created file.
+                                    If specified, the item-level user field takes precedence over defaultUser.
+                                    (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                  format: int64
+                                  type: integer
                               required:
                               - key
                               - path

--- a/spacelift-workerpool-controller/config/crd/bases/workers.spacelift.io_workerpools.yaml
+++ b/spacelift-workerpool-controller/config/crd/bases/workers.spacelift.io_workerpools.yaml
@@ -203,7 +203,9 @@ spec:
                                     description: Selects a key of a ConfigMap.
                                     properties:
                                       key:
-                                        description: The key to select.
+                                        description: |-
+                                          The key to select from the ConfigMap's Data field.
+                                          Keys in the BinaryData field are not currently propagated to container env vars.
                                         type: string
                                       name:
                                         default: ""
@@ -474,6 +476,11 @@ spec:
                                         Number must be in the range 1 to 65535.
                                         Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        Protocol selects the wire protocol for the probe connection.
+                                        Nil defaults to HTTP/1.1.
+                                      type: string
                                     scheme:
                                       description: |-
                                         Scheme to use for connecting to the host.
@@ -587,6 +594,11 @@ spec:
                                         Number must be in the range 1 to 65535.
                                         Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        Protocol selects the wire protocol for the probe connection.
+                                        Nil defaults to HTTP/1.1.
+                                      type: string
                                     scheme:
                                       description: |-
                                         Scheme to use for connecting to the host.
@@ -669,6 +681,13 @@ spec:
                             grpc:
                               description: GRPC specifies a GRPC HealthCheckRequest.
                               properties:
+                                mode:
+                                  description: |-
+                                    mode specifies the connection mode for the gRPC health probe.
+                                    Set to "TLS" to use TLS without certificate verification.
+                                    Set to "Plaintext" to use a plaintext (insecure) connection explicitly.
+                                    If not specified, the probe uses a plaintext (insecure) connection.
+                                  type: string
                                 port:
                                   description: Port number of the gRPC service. Number
                                     must be in the range 1 to 65535.
@@ -727,6 +746,11 @@ spec:
                                     Number must be in the range 1 to 65535.
                                     Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
+                                protocol:
+                                  description: |-
+                                    Protocol selects the wire protocol for the probe connection.
+                                    Nil defaults to HTTP/1.1.
+                                  type: string
                                 scheme:
                                   description: |-
                                     Scheme to use for connecting to the host.
@@ -884,6 +908,13 @@ spec:
                             grpc:
                               description: GRPC specifies a GRPC HealthCheckRequest.
                               properties:
+                                mode:
+                                  description: |-
+                                    mode specifies the connection mode for the gRPC health probe.
+                                    Set to "TLS" to use TLS without certificate verification.
+                                    Set to "Plaintext" to use a plaintext (insecure) connection explicitly.
+                                    If not specified, the probe uses a plaintext (insecure) connection.
+                                  type: string
                                 port:
                                   description: Port number of the gRPC service. Number
                                     must be in the range 1 to 65535.
@@ -942,6 +973,11 @@ spec:
                                     Number must be in the range 1 to 65535.
                                     Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
+                                protocol:
+                                  description: |-
+                                    Protocol selects the wire protocol for the probe connection.
+                                    Nil defaults to HTTP/1.1.
+                                  type: string
                                 scheme:
                                   description: |-
                                     Scheme to use for connecting to the host.
@@ -1397,6 +1433,13 @@ spec:
                             grpc:
                               description: GRPC specifies a GRPC HealthCheckRequest.
                               properties:
+                                mode:
+                                  description: |-
+                                    mode specifies the connection mode for the gRPC health probe.
+                                    Set to "TLS" to use TLS without certificate verification.
+                                    Set to "Plaintext" to use a plaintext (insecure) connection explicitly.
+                                    If not specified, the probe uses a plaintext (insecure) connection.
+                                  type: string
                                 port:
                                   description: Port number of the gRPC service. Number
                                     must be in the range 1 to 65535.
@@ -1455,6 +1498,11 @@ spec:
                                     Number must be in the range 1 to 65535.
                                     Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
+                                protocol:
+                                  description: |-
+                                    Protocol selects the wire protocol for the probe connection.
+                                    Nil defaults to HTTP/1.1.
+                                  type: string
                                 scheme:
                                   description: |-
                                     Scheme to use for connecting to the host.
@@ -1595,10 +1643,21 @@ spec:
                             description: VolumeMount describes a mounting of a Volume
                               within a container.
                             properties:
-                              mountPath:
+                              bindMountOptions:
                                 description: |-
-                                  Path within the container at which the volume should be mounted.  Must
-                                  not contain ':'.
+                                  bindMountOptions is the list of additional bind mount options to apply when
+                                  mounting this volume into the container. Allowed values are noexec,
+                                  nodev, and nosuid. These are Linux mount options and have no effect on
+                                  Windows nodes.
+                                  This field is not supported with image volumes.
+                                  This is an alpha field and requires enabling the VolumeBindMountOptions feature gate.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.
                                 type: string
                               mountPropagation:
                                 description: |-
@@ -2817,6 +2876,13 @@ spec:
                               mode, like fsGroup, and the result can be other mode bits set.
                             format: int32
                             type: integer
+                          defaultUser:
+                            description: |-
+                              defaultUser is Optional: The owner UID of the created files by default.
+                              The defaultUser field is only used as a fallback when the item-level user field is unset.
+                              (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                            format: int64
+                            type: integer
                           items:
                             description: |-
                               items if unspecified, each key-value pair in the Data field of the referenced
@@ -2849,6 +2915,13 @@ spec:
                                     May not contain the path element '..'.
                                     May not start with the string '..'.
                                   type: string
+                                user:
+                                  description: |-
+                                    user is Optional: The owner UID of the created file.
+                                    If specified, the item-level user field takes precedence over defaultUser.
+                                    (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                  format: int64
+                                  type: integer
                               required:
                               - key
                               - path
@@ -2936,6 +3009,13 @@ spec:
                               mode, like fsGroup, and the result can be other mode bits set.
                             format: int32
                             type: integer
+                          defaultUser:
+                            description: |-
+                              defaultUser is Optional: The owner UID of the created files by default.
+                              The defaultUser field is only used as a fallback when the item-level user field is unset.
+                              (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                            format: int64
+                            type: integer
                           items:
                             description: Items is a list of downward API volume file
                             items:
@@ -3000,6 +3080,13 @@ spec:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                user:
+                                  description: |-
+                                    user is Optional: The owner UID of the created file.
+                                    If specified, the item-level user field takes precedence over defaultUser.
+                                    (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                  format: int64
+                                  type: integer
                               required:
                               - path
                               type: object
@@ -3018,6 +3105,18 @@ spec:
                               Must be an empty string (default) or Memory.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                             type: string
+                          mode:
+                            description: |-
+                              mode specifies the permission bits for the emptyDir directory, in numeric
+                              notation (e.g., 0755, 01777). Must be a value between 0000 and 01777.
+                              If not specified, defaults to 0777.
+                              This might be in conflict with other options that affect the file
+                              mode, like fsGroup. If fsGroup is specified, the fsGroup permissions
+                              will override the mode specified here.
+                              This field has no effect on Windows.
+                              This field is alpha and requires EmptyDirVolumeMode featuregate to be enabled.
+                            format: int32
+                            type: integer
                           sizeLimit:
                             anyOf:
                             - type: integer
@@ -3111,8 +3210,8 @@ spec:
                                       * An existing PVC (PersistentVolumeClaim)
                                       If the provisioner or an external controller can support the specified data source,
                                       it will create a new volume based on the contents of the specified data source.
-                                      When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                      and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                      dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be
+                                      copied to dataSource when dataSourceRef.namespace is not specified.
                                       If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                     properties:
                                       apiGroup:
@@ -3157,7 +3256,6 @@ spec:
                                         specified.
                                       * While dataSource only allows local objects, dataSourceRef allows objects
                                         in any namespaces.
-                                      (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
                                       (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                     properties:
                                       apiGroup:
@@ -3724,6 +3822,13 @@ spec:
                               mode, like fsGroup, and the result can be other mode bits set.
                             format: int32
                             type: integer
+                          defaultUser:
+                            description: |-
+                              defaultUser is Optional: The owner UID of the created files by default.
+                              The defaultUser field is only used as a fallback when the item-level user field is unset.
+                              (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                            format: int64
+                            type: integer
                           sources:
                             description: |-
                               sources is the list of volume projections. Each entry in this list
@@ -3823,6 +3928,13 @@ spec:
                                         Mutually-exclusive with name.  The contents of all selected
                                         ClusterTrustBundles will be unified and deduplicated.
                                       type: string
+                                    user:
+                                      description: |-
+                                        user is Optional: The owner UID of the created file.
+                                        If specified, the item-level user field takes precedence over defaultUser.
+                                        (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                      format: int64
+                                      type: integer
                                   required:
                                   - path
                                   type: object
@@ -3863,6 +3975,13 @@ spec:
                                               May not contain the path element '..'.
                                               May not start with the string '..'.
                                             type: string
+                                          user:
+                                            description: |-
+                                              user is Optional: The owner UID of the created file.
+                                              If specified, the item-level user field takes precedence over defaultUser.
+                                              (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                            format: int64
+                                            type: integer
                                         required:
                                         - key
                                         - path
@@ -3958,6 +4077,13 @@ spec:
                                             - resource
                                             type: object
                                             x-kubernetes-map-type: atomic
+                                          user:
+                                            description: |-
+                                              user is Optional: The owner UID of the created file.
+                                              If specified, the item-level user field takes precedence over defaultUser.
+                                              (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                            format: int64
+                                            type: integer
                                         required:
                                         - path
                                         type: object
@@ -4065,6 +4191,13 @@ spec:
                                       description: Kubelet's generated CSRs will be
                                         addressed to this signer.
                                       type: string
+                                    user:
+                                      description: |-
+                                        user is Optional: The owner UID of the created file.
+                                        If specified, the item-level user field takes precedence over defaultUser.
+                                        (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                      format: int64
+                                      type: integer
                                     userAnnotations:
                                       additionalProperties:
                                         type: string
@@ -4124,6 +4257,13 @@ spec:
                                               May not contain the path element '..'.
                                               May not start with the string '..'.
                                             type: string
+                                          user:
+                                            description: |-
+                                              user is Optional: The owner UID of the created file.
+                                              If specified, the item-level user field takes precedence over defaultUser.
+                                              (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                            format: int64
+                                            type: integer
                                         required:
                                         - key
                                         - path
@@ -4171,6 +4311,13 @@ spec:
                                         path is the path relative to the mount point of the file to project the
                                         token into.
                                       type: string
+                                    user:
+                                      description: |-
+                                        user is Optional: The owner UID of the created file.
+                                        If specified, the item-level user field takes precedence over defaultUser.
+                                        (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                      format: int64
+                                      type: integer
                                   required:
                                   - path
                                   type: object
@@ -4377,6 +4524,13 @@ spec:
                               mode, like fsGroup, and the result can be other mode bits set.
                             format: int32
                             type: integer
+                          defaultUser:
+                            description: |-
+                              defaultUser is Optional: The owner UID of the created files by default.
+                              The defaultUser field is only used as a fallback when the item-level user field is unset.
+                              (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                            format: int64
+                            type: integer
                           items:
                             description: |-
                               items If unspecified, each key-value pair in the Data field of the referenced
@@ -4409,6 +4563,13 @@ spec:
                                     May not contain the path element '..'.
                                     May not start with the string '..'.
                                   type: string
+                                user:
+                                  description: |-
+                                    user is Optional: The owner UID of the created file.
+                                    If specified, the item-level user field takes precedence over defaultUser.
+                                    (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                  format: int64
+                                  type: integer
                               required:
                               - key
                               - path
@@ -4576,7 +4737,9 @@ spec:
                                     description: Selects a key of a ConfigMap.
                                     properties:
                                       key:
-                                        description: The key to select.
+                                        description: |-
+                                          The key to select from the ConfigMap's Data field.
+                                          Keys in the BinaryData field are not currently propagated to container env vars.
                                         type: string
                                       name:
                                         default: ""
@@ -4847,6 +5010,11 @@ spec:
                                         Number must be in the range 1 to 65535.
                                         Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        Protocol selects the wire protocol for the probe connection.
+                                        Nil defaults to HTTP/1.1.
+                                      type: string
                                     scheme:
                                       description: |-
                                         Scheme to use for connecting to the host.
@@ -4960,6 +5128,11 @@ spec:
                                         Number must be in the range 1 to 65535.
                                         Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
+                                    protocol:
+                                      description: |-
+                                        Protocol selects the wire protocol for the probe connection.
+                                        Nil defaults to HTTP/1.1.
+                                      type: string
                                     scheme:
                                       description: |-
                                         Scheme to use for connecting to the host.
@@ -5042,6 +5215,13 @@ spec:
                             grpc:
                               description: GRPC specifies a GRPC HealthCheckRequest.
                               properties:
+                                mode:
+                                  description: |-
+                                    mode specifies the connection mode for the gRPC health probe.
+                                    Set to "TLS" to use TLS without certificate verification.
+                                    Set to "Plaintext" to use a plaintext (insecure) connection explicitly.
+                                    If not specified, the probe uses a plaintext (insecure) connection.
+                                  type: string
                                 port:
                                   description: Port number of the gRPC service. Number
                                     must be in the range 1 to 65535.
@@ -5100,6 +5280,11 @@ spec:
                                     Number must be in the range 1 to 65535.
                                     Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
+                                protocol:
+                                  description: |-
+                                    Protocol selects the wire protocol for the probe connection.
+                                    Nil defaults to HTTP/1.1.
+                                  type: string
                                 scheme:
                                   description: |-
                                     Scheme to use for connecting to the host.
@@ -5257,6 +5442,13 @@ spec:
                             grpc:
                               description: GRPC specifies a GRPC HealthCheckRequest.
                               properties:
+                                mode:
+                                  description: |-
+                                    mode specifies the connection mode for the gRPC health probe.
+                                    Set to "TLS" to use TLS without certificate verification.
+                                    Set to "Plaintext" to use a plaintext (insecure) connection explicitly.
+                                    If not specified, the probe uses a plaintext (insecure) connection.
+                                  type: string
                                 port:
                                   description: Port number of the gRPC service. Number
                                     must be in the range 1 to 65535.
@@ -5315,6 +5507,11 @@ spec:
                                     Number must be in the range 1 to 65535.
                                     Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
+                                protocol:
+                                  description: |-
+                                    Protocol selects the wire protocol for the probe connection.
+                                    Nil defaults to HTTP/1.1.
+                                  type: string
                                 scheme:
                                   description: |-
                                     Scheme to use for connecting to the host.
@@ -5770,6 +5967,13 @@ spec:
                             grpc:
                               description: GRPC specifies a GRPC HealthCheckRequest.
                               properties:
+                                mode:
+                                  description: |-
+                                    mode specifies the connection mode for the gRPC health probe.
+                                    Set to "TLS" to use TLS without certificate verification.
+                                    Set to "Plaintext" to use a plaintext (insecure) connection explicitly.
+                                    If not specified, the probe uses a plaintext (insecure) connection.
+                                  type: string
                                 port:
                                   description: Port number of the gRPC service. Number
                                     must be in the range 1 to 65535.
@@ -5828,6 +6032,11 @@ spec:
                                     Number must be in the range 1 to 65535.
                                     Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
+                                protocol:
+                                  description: |-
+                                    Protocol selects the wire protocol for the probe connection.
+                                    Nil defaults to HTTP/1.1.
+                                  type: string
                                 scheme:
                                   description: |-
                                     Scheme to use for connecting to the host.
@@ -5968,10 +6177,21 @@ spec:
                             description: VolumeMount describes a mounting of a Volume
                               within a container.
                             properties:
-                              mountPath:
+                              bindMountOptions:
                                 description: |-
-                                  Path within the container at which the volume should be mounted.  Must
-                                  not contain ':'.
+                                  bindMountOptions is the list of additional bind mount options to apply when
+                                  mounting this volume into the container. Allowed values are noexec,
+                                  nodev, and nosuid. These are Linux mount options and have no effect on
+                                  Windows nodes.
+                                  This field is not supported with image volumes.
+                                  This is an alpha field and requires enabling the VolumeBindMountOptions feature gate.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.
                                 type: string
                               mountPropagation:
                                 description: |-
@@ -6148,7 +6368,9 @@ spec:
                                   description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
+                                      description: |-
+                                        The key to select from the ConfigMap's Data field.
+                                        Keys in the BinaryData field are not currently propagated to container env vars.
                                       type: string
                                     name:
                                       default: ""
@@ -6412,6 +6634,11 @@ spec:
                                       Number must be in the range 1 to 65535.
                                       Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
+                                  protocol:
+                                    description: |-
+                                      Protocol selects the wire protocol for the probe connection.
+                                      Nil defaults to HTTP/1.1.
+                                    type: string
                                   scheme:
                                     description: |-
                                       Scheme to use for connecting to the host.
@@ -6525,6 +6752,11 @@ spec:
                                       Number must be in the range 1 to 65535.
                                       Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
+                                  protocol:
+                                    description: |-
+                                      Protocol selects the wire protocol for the probe connection.
+                                      Nil defaults to HTTP/1.1.
+                                    type: string
                                   scheme:
                                     description: |-
                                       Scheme to use for connecting to the host.
@@ -6842,10 +7074,21 @@ spec:
                           description: VolumeMount describes a mounting of a Volume
                             within a container.
                           properties:
-                            mountPath:
+                            bindMountOptions:
                               description: |-
-                                Path within the container at which the volume should be mounted.  Must
-                                not contain ':'.
+                                bindMountOptions is the list of additional bind mount options to apply when
+                                mounting this volume into the container. Allowed values are noexec,
+                                nodev, and nosuid. These are Linux mount options and have no effect on
+                                Windows nodes.
+                                This field is not supported with image volumes.
+                                This is an alpha field and requires enabling the VolumeBindMountOptions feature gate.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            mountPath:
+                              description: Path within the container at which the
+                                volume should be mounted.
                               type: string
                             mountPropagation:
                               description: |-
@@ -6982,7 +7225,9 @@ spec:
                                   description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
+                                      description: |-
+                                        The key to select from the ConfigMap's Data field.
+                                        Keys in the BinaryData field are not currently propagated to container env vars.
                                       type: string
                                     name:
                                       default: ""
@@ -7246,6 +7491,11 @@ spec:
                                       Number must be in the range 1 to 65535.
                                       Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
+                                  protocol:
+                                    description: |-
+                                      Protocol selects the wire protocol for the probe connection.
+                                      Nil defaults to HTTP/1.1.
+                                    type: string
                                   scheme:
                                     description: |-
                                       Scheme to use for connecting to the host.
@@ -7359,6 +7609,11 @@ spec:
                                       Number must be in the range 1 to 65535.
                                       Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
+                                  protocol:
+                                    description: |-
+                                      Protocol selects the wire protocol for the probe connection.
+                                      Nil defaults to HTTP/1.1.
+                                    type: string
                                   scheme:
                                     description: |-
                                       Scheme to use for connecting to the host.
@@ -7676,10 +7931,21 @@ spec:
                           description: VolumeMount describes a mounting of a Volume
                             within a container.
                           properties:
-                            mountPath:
+                            bindMountOptions:
                               description: |-
-                                Path within the container at which the volume should be mounted.  Must
-                                not contain ':'.
+                                bindMountOptions is the list of additional bind mount options to apply when
+                                mounting this volume into the container. Allowed values are noexec,
+                                nodev, and nosuid. These are Linux mount options and have no effect on
+                                Windows nodes.
+                                This field is not supported with image volumes.
+                                This is an alpha field and requires enabling the VolumeBindMountOptions feature gate.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            mountPath:
+                              description: Path within the container at which the
+                                volume should be mounted.
                               type: string
                             mountPropagation:
                               description: |-
@@ -7876,11 +8142,8 @@ spec:
                           Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
                           whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
                           CSIDriver instance. Other volumes are always re-labelled recursively.
-                          "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
 
-                          If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
-                          If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
-                          and "Recursive" for all other volumes.
+                          If not specified, "MountOption" is used.
 
                           This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
 
@@ -8472,6 +8735,13 @@ spec:
                                 mode, like fsGroup, and the result can be other mode bits set.
                               format: int32
                               type: integer
+                            defaultUser:
+                              description: |-
+                                defaultUser is Optional: The owner UID of the created files by default.
+                                The defaultUser field is only used as a fallback when the item-level user field is unset.
+                                (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                              format: int64
+                              type: integer
                             items:
                               description: |-
                                 items if unspecified, each key-value pair in the Data field of the referenced
@@ -8505,6 +8775,13 @@ spec:
                                       May not contain the path element '..'.
                                       May not start with the string '..'.
                                     type: string
+                                  user:
+                                    description: |-
+                                      user is Optional: The owner UID of the created file.
+                                      If specified, the item-level user field takes precedence over defaultUser.
+                                      (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                    format: int64
+                                    type: integer
                                 required:
                                 - key
                                 - path
@@ -8592,6 +8869,13 @@ spec:
                                 mode, like fsGroup, and the result can be other mode bits set.
                               format: int32
                               type: integer
+                            defaultUser:
+                              description: |-
+                                defaultUser is Optional: The owner UID of the created files by default.
+                                The defaultUser field is only used as a fallback when the item-level user field is unset.
+                                (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                              format: int64
+                              type: integer
                             items:
                               description: Items is a list of downward API volume
                                 file
@@ -8657,6 +8941,13 @@ spec:
                                     - resource
                                     type: object
                                     x-kubernetes-map-type: atomic
+                                  user:
+                                    description: |-
+                                      user is Optional: The owner UID of the created file.
+                                      If specified, the item-level user field takes precedence over defaultUser.
+                                      (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                    format: int64
+                                    type: integer
                                 required:
                                 - path
                                 type: object
@@ -8675,6 +8966,18 @@ spec:
                                 Must be an empty string (default) or Memory.
                                 More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                               type: string
+                            mode:
+                              description: |-
+                                mode specifies the permission bits for the emptyDir directory, in numeric
+                                notation (e.g., 0755, 01777). Must be a value between 0000 and 01777.
+                                If not specified, defaults to 0777.
+                                This might be in conflict with other options that affect the file
+                                mode, like fsGroup. If fsGroup is specified, the fsGroup permissions
+                                will override the mode specified here.
+                                This field has no effect on Windows.
+                                This field is alpha and requires EmptyDirVolumeMode featuregate to be enabled.
+                              format: int32
+                              type: integer
                             sizeLimit:
                               anyOf:
                               - type: integer
@@ -8768,8 +9071,8 @@ spec:
                                         * An existing PVC (PersistentVolumeClaim)
                                         If the provisioner or an external controller can support the specified data source,
                                         it will create a new volume based on the contents of the specified data source.
-                                        When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                        and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                        dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be
+                                        copied to dataSource when dataSourceRef.namespace is not specified.
                                         If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                       properties:
                                         apiGroup:
@@ -8814,7 +9117,6 @@ spec:
                                           specified.
                                         * While dataSource only allows local objects, dataSourceRef allows objects
                                           in any namespaces.
-                                        (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
                                         (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                       properties:
                                         apiGroup:
@@ -9382,6 +9684,13 @@ spec:
                                 mode, like fsGroup, and the result can be other mode bits set.
                               format: int32
                               type: integer
+                            defaultUser:
+                              description: |-
+                                defaultUser is Optional: The owner UID of the created files by default.
+                                The defaultUser field is only used as a fallback when the item-level user field is unset.
+                                (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                              format: int64
+                              type: integer
                             sources:
                               description: |-
                                 sources is the list of volume projections. Each entry in this list
@@ -9481,6 +9790,13 @@ spec:
                                           Mutually-exclusive with name.  The contents of all selected
                                           ClusterTrustBundles will be unified and deduplicated.
                                         type: string
+                                      user:
+                                        description: |-
+                                          user is Optional: The owner UID of the created file.
+                                          If specified, the item-level user field takes precedence over defaultUser.
+                                          (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                        format: int64
+                                        type: integer
                                     required:
                                     - path
                                     type: object
@@ -9521,6 +9837,13 @@ spec:
                                                 May not contain the path element '..'.
                                                 May not start with the string '..'.
                                               type: string
+                                            user:
+                                              description: |-
+                                                user is Optional: The owner UID of the created file.
+                                                If specified, the item-level user field takes precedence over defaultUser.
+                                                (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                              format: int64
+                                              type: integer
                                           required:
                                           - key
                                           - path
@@ -9617,6 +9940,13 @@ spec:
                                               - resource
                                               type: object
                                               x-kubernetes-map-type: atomic
+                                            user:
+                                              description: |-
+                                                user is Optional: The owner UID of the created file.
+                                                If specified, the item-level user field takes precedence over defaultUser.
+                                                (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                              format: int64
+                                              type: integer
                                           required:
                                           - path
                                           type: object
@@ -9724,6 +10054,13 @@ spec:
                                         description: Kubelet's generated CSRs will
                                           be addressed to this signer.
                                         type: string
+                                      user:
+                                        description: |-
+                                          user is Optional: The owner UID of the created file.
+                                          If specified, the item-level user field takes precedence over defaultUser.
+                                          (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                        format: int64
+                                        type: integer
                                       userAnnotations:
                                         additionalProperties:
                                           type: string
@@ -9783,6 +10120,13 @@ spec:
                                                 May not contain the path element '..'.
                                                 May not start with the string '..'.
                                               type: string
+                                            user:
+                                              description: |-
+                                                user is Optional: The owner UID of the created file.
+                                                If specified, the item-level user field takes precedence over defaultUser.
+                                                (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                              format: int64
+                                              type: integer
                                           required:
                                           - key
                                           - path
@@ -9830,6 +10174,13 @@ spec:
                                           path is the path relative to the mount point of the file to project the
                                           token into.
                                         type: string
+                                      user:
+                                        description: |-
+                                          user is Optional: The owner UID of the created file.
+                                          If specified, the item-level user field takes precedence over defaultUser.
+                                          (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                        format: int64
+                                        type: integer
                                     required:
                                     - path
                                     type: object
@@ -10036,6 +10387,13 @@ spec:
                                 mode, like fsGroup, and the result can be other mode bits set.
                               format: int32
                               type: integer
+                            defaultUser:
+                              description: |-
+                                defaultUser is Optional: The owner UID of the created files by default.
+                                The defaultUser field is only used as a fallback when the item-level user field is unset.
+                                (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                              format: int64
+                              type: integer
                             items:
                               description: |-
                                 items If unspecified, each key-value pair in the Data field of the referenced
@@ -10069,6 +10427,13 @@ spec:
                                       May not contain the path element '..'.
                                       May not start with the string '..'.
                                     type: string
+                                  user:
+                                    description: |-
+                                      user is Optional: The owner UID of the created file.
+                                      If specified, the item-level user field takes precedence over defaultUser.
+                                      (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                    format: int64
+                                    type: integer
                                 required:
                                 - key
                                 - path
@@ -10200,7 +10565,9 @@ spec:
                                   description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
+                                      description: |-
+                                        The key to select from the ConfigMap's Data field.
+                                        Keys in the BinaryData field are not currently propagated to container env vars.
                                       type: string
                                     name:
                                       default: ""
@@ -10464,6 +10831,11 @@ spec:
                                       Number must be in the range 1 to 65535.
                                       Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
+                                  protocol:
+                                    description: |-
+                                      Protocol selects the wire protocol for the probe connection.
+                                      Nil defaults to HTTP/1.1.
+                                    type: string
                                   scheme:
                                     description: |-
                                       Scheme to use for connecting to the host.
@@ -10577,6 +10949,11 @@ spec:
                                       Number must be in the range 1 to 65535.
                                       Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
+                                  protocol:
+                                    description: |-
+                                      Protocol selects the wire protocol for the probe connection.
+                                      Nil defaults to HTTP/1.1.
+                                    type: string
                                   scheme:
                                     description: |-
                                       Scheme to use for connecting to the host.
@@ -10894,10 +11271,21 @@ spec:
                           description: VolumeMount describes a mounting of a Volume
                             within a container.
                           properties:
-                            mountPath:
+                            bindMountOptions:
                               description: |-
-                                Path within the container at which the volume should be mounted.  Must
-                                not contain ':'.
+                                bindMountOptions is the list of additional bind mount options to apply when
+                                mounting this volume into the container. Allowed values are noexec,
+                                nodev, and nosuid. These are Linux mount options and have no effect on
+                                Windows nodes.
+                                This field is not supported with image volumes.
+                                This is an alpha field and requires enabling the VolumeBindMountOptions feature gate.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                            mountPath:
+                              description: Path within the container at which the
+                                volume should be mounted.
                               type: string
                             mountPropagation:
                               description: |-
@@ -11172,6 +11560,13 @@ spec:
                               mode, like fsGroup, and the result can be other mode bits set.
                             format: int32
                             type: integer
+                          defaultUser:
+                            description: |-
+                              defaultUser is Optional: The owner UID of the created files by default.
+                              The defaultUser field is only used as a fallback when the item-level user field is unset.
+                              (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                            format: int64
+                            type: integer
                           items:
                             description: |-
                               items if unspecified, each key-value pair in the Data field of the referenced
@@ -11204,6 +11599,13 @@ spec:
                                     May not contain the path element '..'.
                                     May not start with the string '..'.
                                   type: string
+                                user:
+                                  description: |-
+                                    user is Optional: The owner UID of the created file.
+                                    If specified, the item-level user field takes precedence over defaultUser.
+                                    (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                  format: int64
+                                  type: integer
                               required:
                               - key
                               - path
@@ -11291,6 +11693,13 @@ spec:
                               mode, like fsGroup, and the result can be other mode bits set.
                             format: int32
                             type: integer
+                          defaultUser:
+                            description: |-
+                              defaultUser is Optional: The owner UID of the created files by default.
+                              The defaultUser field is only used as a fallback when the item-level user field is unset.
+                              (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                            format: int64
+                            type: integer
                           items:
                             description: Items is a list of downward API volume file
                             items:
@@ -11355,6 +11764,13 @@ spec:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                user:
+                                  description: |-
+                                    user is Optional: The owner UID of the created file.
+                                    If specified, the item-level user field takes precedence over defaultUser.
+                                    (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                  format: int64
+                                  type: integer
                               required:
                               - path
                               type: object
@@ -11373,6 +11789,18 @@ spec:
                               Must be an empty string (default) or Memory.
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                             type: string
+                          mode:
+                            description: |-
+                              mode specifies the permission bits for the emptyDir directory, in numeric
+                              notation (e.g., 0755, 01777). Must be a value between 0000 and 01777.
+                              If not specified, defaults to 0777.
+                              This might be in conflict with other options that affect the file
+                              mode, like fsGroup. If fsGroup is specified, the fsGroup permissions
+                              will override the mode specified here.
+                              This field has no effect on Windows.
+                              This field is alpha and requires EmptyDirVolumeMode featuregate to be enabled.
+                            format: int32
+                            type: integer
                           sizeLimit:
                             anyOf:
                             - type: integer
@@ -11466,8 +11894,8 @@ spec:
                                       * An existing PVC (PersistentVolumeClaim)
                                       If the provisioner or an external controller can support the specified data source,
                                       it will create a new volume based on the contents of the specified data source.
-                                      When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                      and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                      dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be
+                                      copied to dataSource when dataSourceRef.namespace is not specified.
                                       If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                     properties:
                                       apiGroup:
@@ -11512,7 +11940,6 @@ spec:
                                         specified.
                                       * While dataSource only allows local objects, dataSourceRef allows objects
                                         in any namespaces.
-                                      (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
                                       (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                     properties:
                                       apiGroup:
@@ -12079,6 +12506,13 @@ spec:
                               mode, like fsGroup, and the result can be other mode bits set.
                             format: int32
                             type: integer
+                          defaultUser:
+                            description: |-
+                              defaultUser is Optional: The owner UID of the created files by default.
+                              The defaultUser field is only used as a fallback when the item-level user field is unset.
+                              (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                            format: int64
+                            type: integer
                           sources:
                             description: |-
                               sources is the list of volume projections. Each entry in this list
@@ -12178,6 +12612,13 @@ spec:
                                         Mutually-exclusive with name.  The contents of all selected
                                         ClusterTrustBundles will be unified and deduplicated.
                                       type: string
+                                    user:
+                                      description: |-
+                                        user is Optional: The owner UID of the created file.
+                                        If specified, the item-level user field takes precedence over defaultUser.
+                                        (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                      format: int64
+                                      type: integer
                                   required:
                                   - path
                                   type: object
@@ -12218,6 +12659,13 @@ spec:
                                               May not contain the path element '..'.
                                               May not start with the string '..'.
                                             type: string
+                                          user:
+                                            description: |-
+                                              user is Optional: The owner UID of the created file.
+                                              If specified, the item-level user field takes precedence over defaultUser.
+                                              (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                            format: int64
+                                            type: integer
                                         required:
                                         - key
                                         - path
@@ -12313,6 +12761,13 @@ spec:
                                             - resource
                                             type: object
                                             x-kubernetes-map-type: atomic
+                                          user:
+                                            description: |-
+                                              user is Optional: The owner UID of the created file.
+                                              If specified, the item-level user field takes precedence over defaultUser.
+                                              (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                            format: int64
+                                            type: integer
                                         required:
                                         - path
                                         type: object
@@ -12420,6 +12875,13 @@ spec:
                                       description: Kubelet's generated CSRs will be
                                         addressed to this signer.
                                       type: string
+                                    user:
+                                      description: |-
+                                        user is Optional: The owner UID of the created file.
+                                        If specified, the item-level user field takes precedence over defaultUser.
+                                        (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                      format: int64
+                                      type: integer
                                     userAnnotations:
                                       additionalProperties:
                                         type: string
@@ -12479,6 +12941,13 @@ spec:
                                               May not contain the path element '..'.
                                               May not start with the string '..'.
                                             type: string
+                                          user:
+                                            description: |-
+                                              user is Optional: The owner UID of the created file.
+                                              If specified, the item-level user field takes precedence over defaultUser.
+                                              (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                            format: int64
+                                            type: integer
                                         required:
                                         - key
                                         - path
@@ -12526,6 +12995,13 @@ spec:
                                         path is the path relative to the mount point of the file to project the
                                         token into.
                                       type: string
+                                    user:
+                                      description: |-
+                                        user is Optional: The owner UID of the created file.
+                                        If specified, the item-level user field takes precedence over defaultUser.
+                                        (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                      format: int64
+                                      type: integer
                                   required:
                                   - path
                                   type: object
@@ -12732,6 +13208,13 @@ spec:
                               mode, like fsGroup, and the result can be other mode bits set.
                             format: int32
                             type: integer
+                          defaultUser:
+                            description: |-
+                              defaultUser is Optional: The owner UID of the created files by default.
+                              The defaultUser field is only used as a fallback when the item-level user field is unset.
+                              (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                            format: int64
+                            type: integer
                           items:
                             description: |-
                               items If unspecified, each key-value pair in the Data field of the referenced
@@ -12764,6 +13247,13 @@ spec:
                                     May not contain the path element '..'.
                                     May not start with the string '..'.
                                   type: string
+                                user:
+                                  description: |-
+                                    user is Optional: The owner UID of the created file.
+                                    If specified, the item-level user field takes precedence over defaultUser.
+                                    (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                  format: int64
+                                  type: integer
                               required:
                               - key
                               - path

--- a/spacelift-workerpool-controller/values.yaml
+++ b/spacelift-workerpool-controller/values.yaml
@@ -24,7 +24,7 @@ controllerManager:
         - ALL
     image:
       repository: public.ecr.aws/spacelift/kube-workerpool-controller
-      tag: v0.0.41
+      tag: v0.0.42
     resources:
       limits:
         memory: 128Mi


### PR DESCRIPTION
Update the controller image to v0.0.42 and refresh the WorkerPool CRD.

The controller now retries worker pool updates against Spacelift when they fail part way through, hashes worker pool label keys as well as values so label-only changes are picked up, and passes the pool's comms protocol to the gRPC sidecar of run pods. It is built with Go 1.27.1 and patched dependencies.

The CRD changes come from the Kubernetes 1.37 API types embedded in spec.pod: probes gain protocol, volume mounts gain bindMountOptions, and configMap, secret and projected volumes gain user ownership settings. All additions are optional, so existing WorkerPool objects stay valid and the new image also runs against the previous CRDs.

- [x] A chart version is updated
  - [ ] No changes on CRDs
  - [x] CRDs are updated
